### PR TITLE
[SPRINT3] Participant list send to clients

### DIFF
--- a/core/src/main/scala/it/cwmp/controller/ApiClient.scala
+++ b/core/src/main/scala/it/cwmp/controller/ApiClient.scala
@@ -11,6 +11,11 @@ import io.vertx.scala.ext.web.client.{WebClient, WebClientOptions}
 trait ApiClient {
 
   /**
+    * @return A new WebClient
+    */
+  def createWebClient(): WebClient = WebClient.create(Vertx.vertx)
+
+  /**
     * Creates a new WebClient that will do it's calls to "host" at "port"
     *
     * @param host the host to contact

--- a/core/src/main/scala/it/cwmp/model/Participant.scala
+++ b/core/src/main/scala/it/cwmp/model/Participant.scala
@@ -1,7 +1,7 @@
 package it.cwmp.model
 
 import io.vertx.lang.scala.json.JsonObject
-import it.cwmp.model.User.Converters.{JsonUserConverter, RichUser, parseException}
+import it.cwmp.model.User.Converters.{JsonUserConverter, RichUser}
 import it.cwmp.utils.Utils._
 
 trait Participant extends User with Address
@@ -16,7 +16,7 @@ object Participant {
     ParticipantImpl(username, address)
   }
 
-  def unapply(toExtract: Participant)(implicit d: DummyImplicit): Option[(String, String)] =
+  def unapply(toExtract: Participant): Option[(String, String)] =
     if (toExtract eq null) None else Some(toExtract.username, toExtract.address)
 
   private case class ParticipantImpl(username: String, address: String) extends Participant
@@ -44,5 +44,7 @@ object Participant {
         if (json containsKey FIELD_ADDRESS) Participant(super.toUser.username, json getString FIELD_ADDRESS)
         else throw parseException("Participant JsonParsing", s"The input doesn't contain $FIELD_ADDRESS --> ${json encodePrettily()}")
     }
+
   }
+
 }

--- a/core/src/main/scala/it/cwmp/model/Room.scala
+++ b/core/src/main/scala/it/cwmp/model/Room.scala
@@ -1,9 +1,7 @@
 package it.cwmp.model
 
-import java.text.ParseException
-
 import io.vertx.lang.scala.json.{Json, JsonObject}
-import it.cwmp.utils.Utils
+import it.cwmp.utils.Utils._
 
 /**
   * Trait that describes the Room
@@ -26,7 +24,6 @@ sealed trait Room {
   * @author Enrico Siboni
   */
 object Room {
-  import Utils.emptyString
 
   def apply(roomID: String,
             roomName: String,
@@ -104,8 +101,8 @@ object Room {
             jsonObject getInteger FIELD_NEEDED_PLAYERS,
             userSeq)
         } else {
-          throw new ParseException(s"The input doesn't contain one or more of: " +
-            s"$FIELD_IDENTIFIER, $FIELD_NAME, $FIELD_NEEDED_PLAYERS, $FIELD_PARTICIPANTS --> ${jsonObject.encodePrettily()}", 0)
+          throw parseException("Room Parsing", s"The input doesn't contain one or more of: " +
+            s"$FIELD_IDENTIFIER, $FIELD_NAME, $FIELD_NEEDED_PLAYERS, $FIELD_PARTICIPANTS --> ${jsonObject.encodePrettily()}")
         }
       }
     }

--- a/core/src/main/scala/it/cwmp/model/User.scala
+++ b/core/src/main/scala/it/cwmp/model/User.scala
@@ -1,7 +1,5 @@
 package it.cwmp.model
 
-import java.text.ParseException
-
 import io.vertx.lang.scala.json.{Json, JsonObject}
 import it.cwmp.utils.Utils._
 
@@ -56,11 +54,6 @@ object User {
         else throw parseException("User JsonParsing", s"The input doesn't contain $FIELD_USERNAME --> ${json encodePrettily()}")
     }
 
-    /**
-      * @return the ParseException filled with error string
-      */
-    private[model] def parseException(context: String, errorMessage: String): ParseException =
-      new ParseException(s"$context: $errorMessage", 0)
   }
 
 }

--- a/core/src/main/scala/it/cwmp/utils/Utils.scala
+++ b/core/src/main/scala/it/cwmp/utils/Utils.scala
@@ -1,8 +1,10 @@
 package it.cwmp.utils
 
+import java.text.ParseException
+
 object Utils {
 
-  def randomString(length: Int) = scala.util.Random.alphanumeric.take(length).mkString
+  def randomString(length: Int): String = scala.util.Random.alphanumeric.take(length).mkString
 
   /**
     * Utility method to test if a string is empty
@@ -11,4 +13,10 @@ object Utils {
     * @return true if string is empty, false otherwise
     */
   def emptyString(string: String): Boolean = string == null || string.isEmpty
+
+  /**
+    * @return the ParseException filled with error string
+    */
+  def parseException(context: String, errorMessage: String): ParseException =
+    new ParseException(s"$context: $errorMessage", 0)
 }

--- a/server/room-receiver/src/main/scala/it/cwmp/roomreceiver/controller/RoomReceiverServiceVerticle.scala
+++ b/server/room-receiver/src/main/scala/it/cwmp/roomreceiver/controller/RoomReceiverServiceVerticle.scala
@@ -10,12 +10,6 @@ import it.cwmp.model.Participant
 
 import scala.concurrent.Future
 
-object RoomReceiverServiceVerticle {
-
-  def apply(url: String, receptionStrategy: Seq[Participant] => Unit): RoomReceiverServiceVerticle =
-    new RoomReceiverServiceVerticle(url, receptionStrategy)
-}
-
 case class RoomReceiverServiceVerticle(token: String, receptionStrategy: Seq[Participant] => Unit) extends ScalaVerticle {
 
   var server: HttpServer = _

--- a/server/room-receiver/src/test/scala/it/cwmp/roomreceiver/controller/RoomReceiverServiceVerticleTest.scala
+++ b/server/room-receiver/src/test/scala/it/cwmp/roomreceiver/controller/RoomReceiverServiceVerticleTest.scala
@@ -1,7 +1,7 @@
 package it.cwmp.roomreceiver.controller
 
 import io.vertx.lang.scala.json.Json
-import io.vertx.scala.ext.web.client.{WebClient, WebClientOptions}
+import it.cwmp.controller.ApiClient
 import it.cwmp.controller.client.RoomReceiverApiWrapper
 import it.cwmp.exceptions.HTTPException
 import it.cwmp.model.Participant
@@ -13,20 +13,14 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Promise}
 import scala.util.{Failure, Success}
 
-class RoomReceiverServiceVerticleTest extends VertxTest with BeforeAndAfterEach with Matchers {
+class RoomReceiverServiceVerticleTest extends VertxTest with BeforeAndAfterEach with Matchers with ApiClient {
 
   private val token = "barabba"
   private val wrongToken = "rabarbaro"
   private val list = Participant("Nome", "Indirizzo") :: Participant("Nome1", "Indirizzo1") :: List[Participant]()
   private var promiseList: Promise[Seq[Participant]] = _
 
-  private def client = {
-    val options = WebClientOptions()
-      .setDefaultHost("localhost")
-      .setDefaultPort(RoomReceiverApiWrapper.DEFAULT_PORT)
-      .setKeepAlive(false)
-    WebClient.create(vertx, options)
-  }
+  private def client = createWebClient("localhost", RoomReceiverApiWrapper.DEFAULT_PORT, vertx)
 
   private var deploymentID: String = _
 
@@ -71,7 +65,7 @@ class RoomReceiverServiceVerticleTest extends VertxTest with BeforeAndAfterEach 
             .sendFuture()
             .transform({
               case Success(res) if res.statusCode() == 201 => Success(Unit)
-              case Success(res) => Failure(HTTPException(res.statusCode()))// TODO: add an error message as second argument of HTTP exception
+              case Success(res) => Failure(HTTPException(res.statusCode())) // TODO: add an error message as second argument of HTTP exception
               case Failure(f) => Failure(f)
             })
             .flatMap(_ => client.post(RoomReceiverApiWrapper.API_RECEIVE_PARTICIPANTS_URL(token))

--- a/server/rooms/src/main/scala/it/cwmp/RoomsServiceMain.scala
+++ b/server/rooms/src/main/scala/it/cwmp/RoomsServiceMain.scala
@@ -12,7 +12,7 @@ import it.cwmp.controller.rooms.RoomsServiceVerticle
   */
 object RoomsServiceMain extends App {
 
-  private implicit val vertx: Vertx = Vertx.vertx()
+  private val vertx: Vertx = Vertx.vertx()
   vertx.deployVerticle(RoomsServiceVerticle(AuthenticationService(), RoomReceiverApiWrapper()))
 
   println("Deploying RoomServiceVerticle... ") // TODO replace with logger logging

--- a/server/rooms/src/main/scala/it/cwmp/controller/rooms/RoomsServiceVerticle.scala
+++ b/server/rooms/src/main/scala/it/cwmp/controller/rooms/RoomsServiceVerticle.scala
@@ -93,7 +93,8 @@ case class RoomsServiceVerticle(validationStrategy: Validation[String, User],
               case Success(_) => handlePrivateRoomFilling(roomID)
                 .transform({
                   case Success(_) => Failure(new Exception())
-                  case Failure(_) => Success(Unit)
+                  case Failure(_: NoSuchElementException) => Success(Unit)
+                  case Failure(ex) => println(ex); Success(Unit)
                 })
                 .map(_ => sendResponse(200, None))
               case Failure(ex: NoSuchElementException) => sendResponse(404, Some(ex.getMessage))
@@ -172,7 +173,8 @@ case class RoomsServiceVerticle(validationStrategy: Validation[String, User],
               case Success(_) => handlePublicRoomFilling(playersNumber)
                 .transform({
                   case Success(_) => Failure(new Exception())
-                  case Failure(_) => Success(Unit)
+                  case Failure(_: NoSuchElementException) => Success(Unit)
+                  case Failure(ex) => println(ex); Success(Unit)
                 })
                 .map(_ => sendResponse(200, None))
               case Failure(ex: NoSuchElementException) => sendResponse(404, Some(ex.getMessage))
@@ -349,7 +351,7 @@ object RoomsServiceVerticle {
                                        executionContext: ExecutionContext): Future[Unit] = {
     val participantList = for (participant <- room.participants) yield participant
     Future.sequence {
-      participantList map (participant => communicationStrategy.sendParticipantAddresses(participant.address, participantList filter (_ != participant)))
+      participantList map (participant => communicationStrategy.sendParticipantAddresses(participant.address, participantList))
     } map (_ => Unit)
   }
 


### PR DESCRIPTION
- Added debug println if sending to clients fails
- Added a createClient call to ApiClient to create plain webClient
- Removed redundant companion object for class RoomReceiverServiceVerticle (case classes always have apply by default)
- Now roomsService sends all Participants to all Participants, so everyone receives even itself in list
https://trello.com/c/7schjKE7