### PR TITLE
[SPRINT4] Gradle jar production

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ group = projectGroup
 version = projectVersion
 description = projectDescription
 
+def jarDestinationFolder = "${rootDir.path}$productionJarFolder"
+
 allprojects {
     apply plugin: 'idea'
     apply plugin: 'eclipse'
@@ -48,15 +50,7 @@ subprojects {
     if (project.name == 'client' || project.name == 'rooms' || project.name == 'authentication') {
         apply plugin: 'com.github.johnrengelman.shadow'
 
-        def jarDestinationFolder = "${rootDir.path}$productionJarFolder"
-
         shadowJar {
-            doFirst {
-                // delete old jars
-                if (fileTree(jarDestinationFolder).files.size() == 3)
-                    delete(fileTree(jarDestinationFolder))
-            }
-
             baseName = artifactId
             version = projectVersion
             classifier = project.name
@@ -64,6 +58,11 @@ subprojects {
             destinationDir = file(jarDestinationFolder)
             mergeServiceFiles('reference.conf') // solves problems with AKKA
         }
+    }
+
+    clean {
+        // delete production folder
+        delete(file(jarDestinationFolder))
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,6 @@ group = projectGroup
 version = projectVersion
 description = projectDescription
 
-def myJarDestinationFolder = rootDir.path + '/production'
-
 allprojects {
     apply plugin: 'idea'
     apply plugin: 'eclipse'
@@ -50,25 +48,24 @@ subprojects {
     if (project.name == 'client' || project.name == 'rooms' || project.name == 'authentication') {
         apply plugin: 'com.github.johnrengelman.shadow'
 
+        def jarDestinationFolder = "${rootDir.path}$productionJarFolder"
+
         shadowJar {
             doFirst {
                 // delete old jars
-                if (fileTree(myJarDestinationFolder).files.size() == 3)
-                    delete(fileTree(myJarDestinationFolder))
+                if (fileTree(jarDestinationFolder).files.size() == 3)
+                    delete(fileTree(jarDestinationFolder))
             }
 
-            baseName = 'cwmp'
+            baseName = artifactId
             version = projectVersion
+            classifier = project.name
 
-            destinationDir = file(myJarDestinationFolder)
+            destinationDir = file(jarDestinationFolder)
             mergeServiceFiles('reference.conf') // solves problems with AKKA
         }
     }
 }
-
-project(':client') { shadowJar { classifier = 'Client' } }
-project(':services:rooms') { shadowJar { classifier = 'RoomService' } }
-project(':services:authentication') { shadowJar { classifier = 'AuthenticationService' } }
 
 configure(subprojects.findAll { it.name == 'core' || it.parent.name == 'services' }) {
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ group = projectGroup
 version = projectVersion
 description = projectDescription
 
+def myJarDestinationFolder = rootDir.path + '/production'
+
 allprojects {
     apply plugin: 'idea'
     apply plugin: 'eclipse'
@@ -24,7 +26,7 @@ subprojects {
     sourceCompatibility = "$jdkVersion"
     javadoc.destinationDir = file("$docsFolderJava/${it.path}")
     scaladoc.destinationDir = file("$docsFolderScala/${it.path}")
-    
+
     dependencies {
         if (project.name != 'core') {
             implementation project(':core')
@@ -44,7 +46,29 @@ subprojects {
         scoverage 'org.scoverage:scalac-scoverage-plugin_2.12:1.3.1'
         scoverage 'org.scoverage:scalac-scoverage-runtime_2.12:1.3.1'
     }
+
+    if (project.name == 'client' || project.name == 'rooms' || project.name == 'authentication') {
+        apply plugin: 'com.github.johnrengelman.shadow'
+
+        shadowJar {
+            doFirst {
+                // delete old jars
+                if (fileTree(myJarDestinationFolder).files.size() == 3)
+                    delete(fileTree(myJarDestinationFolder))
+            }
+
+            baseName = 'cwmp'
+            version = projectVersion
+
+            destinationDir = file(myJarDestinationFolder)
+            mergeServiceFiles('reference.conf') // solves problems with AKKA
+        }
+    }
 }
+
+project(':client') { shadowJar { classifier = 'Client' } }
+project(':services:rooms') { shadowJar { classifier = 'RoomService' } }
+project(':services:authentication') { shadowJar { classifier = 'AuthenticationService' } }
 
 configure(subprojects.findAll { it.name == 'core' || it.parent.name == 'services' }) {
 
@@ -74,6 +98,9 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.org.scoverage:gradle-scoverage:2.3.0"
         classpath "gradle.plugin.com.github.maiflai:gradle-scalatest:0.22"
+
+        // to build fatJars
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
     }
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,4 +1,4 @@
-apply plugin:'application'
+apply plugin: 'application'
 
 mainClassName = 'it.cwmp.client.ClientMain'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,4 @@ jdkVersion = 1.8
 
 docsFolderJava = latest-docs/java
 docsFolderScala = latest-docs/scala
+productionJarFolder = /production


### PR DESCRIPTION
Modified root gradle build script to produce executable *services jars* and *client jar*

Now you can execute `gradlew shadowJar` on the root project and have the production jars put in a `production` folder.

Anyway I suggest executing `gradlew clean shadowJar`, because shadowJar doesn't replace old generated jars

[IT9] https://trello.com/c/Lo7mhmdM