### PR TITLE
[SPRINT5] BUGFIX Solved a problem in authentication process

### DIFF
--- a/core/src/main/scala/it/cwmp/services/wrapper/AuthenticationApiWrapper.scala
+++ b/core/src/main/scala/it/cwmp/services/wrapper/AuthenticationApiWrapper.scala
@@ -57,14 +57,14 @@ object AuthenticationApiWrapper {
         .expectStatus(200)
         .map(_.bodyAsString().getOrElse(""))
 
-    override def validate(authenticationHeader: String): Future[User] ={
+    override def validate(authenticationHeader: String): Future[User] =
       client.get(API_VALIDATE)
         .addAuthenticationHeader(authenticationHeader)
         .sendFuture()
         .expectStatus(200)
         .mapBody {
           case Some(body) => Future.successful(User(body))
-          case _ => Future.failed(HTTPException(400, "Empty body"))}
+          case _ => Future.failed(HTTPException(400, "Empty body"))
         }
   }
 

--- a/core/src/main/scala/it/cwmp/services/wrapper/AuthenticationApiWrapper.scala
+++ b/core/src/main/scala/it/cwmp/services/wrapper/AuthenticationApiWrapper.scala
@@ -57,14 +57,14 @@ object AuthenticationApiWrapper {
         .expectStatus(200)
         .map(_.bodyAsString().getOrElse(""))
 
-    override def validate(token: String): Future[User] =
+    override def validate(authenticationHeader: String): Future[User] ={
       client.get(API_VALIDATE)
-        .addAuthentication(token)
+        .addAuthenticationHeader(authenticationHeader)
         .sendFuture()
         .expectStatus(200)
         .mapBody {
           case Some(body) => Future.successful(User(body))
-          case _ => Future.failed(HTTPException(400, "Empty body"))
+          case _ => Future.failed(HTTPException(400, "Empty body"))}
         }
   }
 

--- a/core/src/main/scala/it/cwmp/utils/VertxClient.scala
+++ b/core/src/main/scala/it/cwmp/utils/VertxClient.scala
@@ -113,7 +113,7 @@ trait VertxClient {
     def expectStatus(statusCode: Int*): Future[HttpResponse[T]] = {
       response.transform {
         case s@Success(res) if statusCode.contains(res.statusCode()) => s
-        case Success(res) => Failure(HTTPException(res.statusCode(), "Invalid response code"))
+        case Success(res) => Failure(HTTPException(res.statusCode(), s"Error code: ${res.statusCode()}"))
         case f@Failure(_) => f
       }
     }

--- a/core/src/main/scala/it/cwmp/utils/VertxClient.scala
+++ b/core/src/main/scala/it/cwmp/utils/VertxClient.scala
@@ -65,7 +65,7 @@ trait VertxClient {
       */
     def addAuthentication(username: String, password: String): HttpRequest[T] =
       HttpUtils.buildBasicAuthentication(username, password)
-        .map(request.putHeader(HttpHeaderNames.AUTHORIZATION.toString, _))
+        .map(putRequestAuthorizationHeader(request, _))
         .getOrElse(request)
 
     /**
@@ -76,8 +76,27 @@ trait VertxClient {
       */
     def addAuthentication(implicit token: String): HttpRequest[T] =
       HttpUtils.buildJwtAuthentication(token)
-        .map(request.putHeader(HttpHeaderNames.AUTHORIZATION.toString, _))
+        .map(putRequestAuthorizationHeader(request, _))
         .getOrElse(request)
+
+    /**
+      * Simplified way to add an authorization header as is in request
+      *
+      * @param authenticationHeader the authorization header to add as is
+      * @return the same [[HttpRequest]] enriched, with the authorization header
+      */
+    def addAuthenticationHeader(implicit authenticationHeader: String): HttpRequest[T] =
+      putRequestAuthorizationHeader(request, authenticationHeader)
+
+    /**
+      * Utility mthod to put the authorization header in request
+      *
+      * @param request             the request
+      * @param authorizationHeader the authorization header to put
+      * @return the request with provided header
+      */
+    private def putRequestAuthorizationHeader(request: HttpRequest[T], authorizationHeader: String): HttpRequest[T] =
+      request.putHeader(HttpHeaderNames.AUTHORIZATION.toString, authorizationHeader)
   }
 
   /**

--- a/core/src/main/scala/it/cwmp/utils/VertxServer.scala
+++ b/core/src/main/scala/it/cwmp/utils/VertxServer.scala
@@ -114,11 +114,11 @@ trait VertxServer extends ScalaVerticle {
       * @return A future containing the authenticated user, if present, otherwise it fails with a [[HTTPException]]
       */
     def checkAuthentication(implicit strategy: Validation[String, User],
-                            routingContext: RoutingContext): Future[User] = getAuthentication match {
+                            routingContext: RoutingContext): Future[User] = getAuthenticationHeader match {
       case None =>
         log.warn(NO_AUTH_HEADER_IN_REQUEST_ERROR)
         Future.failed(HTTPException(400, NO_AUTH_HEADER_IN_REQUEST_ERROR))
-      case Some(authentication) => strategy.validate(authentication)
+      case Some(authenticationHeader) => strategy.validate(authenticationHeader)
     }
 
     /**
@@ -140,11 +140,11 @@ trait VertxServer extends ScalaVerticle {
       }
 
     /**
-      * Reads the authorization token in the request.
+      * Reads the authorization header (with token) in the request.
       *
       * @return An optional containing the header, if present. Otherwise None
       */
-    def getAuthentication: Option[String] = request.getHeader(HttpHeaderNames.AUTHORIZATION.toString)
+    def getAuthenticationHeader: Option[String] = request.getHeader(HttpHeaderNames.AUTHORIZATION.toString)
   }
 
 }

--- a/core/src/test/scala/it/cwmp/services/wrapper/AuthenticationApiWrapperTest.scala
+++ b/core/src/test/scala/it/cwmp/services/wrapper/AuthenticationApiWrapperTest.scala
@@ -14,6 +14,11 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
 
   private val auth = AuthenticationApiWrapper()
 
+  /**
+    * @return a new authentication header with a token
+    */
+  protected def nextHeader: String = HttpUtils.buildJwtAuthentication(super.nextToken).get
+
   override protected def singUpTests(): Unit = {
     it("when right should succeed") {
       val username = nextUsername
@@ -103,11 +108,11 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
       promiseResult.future.map(_ => succeed)
     }
 
-    it("when unauthorized token should fail") {
-      val myToken = nextToken
+    it("when unauthorized header should fail") {
+      val myAuthHeader = nextHeader
 
       val promiseResult: Promise[Unit] = Promise()
-      auth.validate(HttpUtils.buildJwtAuthentication(myToken).get)
+      auth.validate(myAuthHeader)
         .onComplete({
           case Failure(HTTPException(statusCode, _)) if statusCode == 401 => promiseResult.success(Unit)
           case _ => promiseResult.failure(new Exception)

--- a/core/src/test/scala/it/cwmp/services/wrapper/AuthenticationApiWrapperTest.scala
+++ b/core/src/test/scala/it/cwmp/services/wrapper/AuthenticationApiWrapperTest.scala
@@ -2,7 +2,7 @@ package it.cwmp.services.wrapper
 
 import it.cwmp.exceptions.HTTPException
 import it.cwmp.services.testing.authentication.AuthenticationWebServiceTesting
-import it.cwmp.utils.{HttpUtils, Utils}
+import it.cwmp.utils.HttpUtils
 
 import scala.concurrent.Promise
 import scala.util.Failure

--- a/core/src/test/scala/it/cwmp/services/wrapper/AuthenticationApiWrapperTest.scala
+++ b/core/src/test/scala/it/cwmp/services/wrapper/AuthenticationApiWrapperTest.scala
@@ -2,7 +2,7 @@ package it.cwmp.services.wrapper
 
 import it.cwmp.exceptions.HTTPException
 import it.cwmp.services.testing.authentication.AuthenticationWebServiceTesting
-import it.cwmp.utils.Utils
+import it.cwmp.utils.{HttpUtils, Utils}
 
 import scala.concurrent.Promise
 import scala.util.Failure
@@ -14,8 +14,8 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
 
   private val auth = AuthenticationApiWrapper()
 
-  override protected def singupTests(): Unit = {
-    it("when right should succed") {
+  override protected def singUpTests(): Unit = {
+    it("when right should succeed") {
       val username = nextUsername
       val password = nextPassword
 
@@ -38,12 +38,12 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
     }
   }
 
-  override protected def signoutTests(): Unit = {
+  override protected def signOutTests(): Unit = {
     // TODO implementation
   }
 
   override protected def loginTests(): Unit = {
-    it("when right should succed") {
+    it("when right should succeed") {
       val username = nextUsername
       val password = nextPassword
 
@@ -68,7 +68,7 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
     it("when password is wrong should fail") {
       val username = nextUsername
       val password = nextPassword
-      val passwordWrong = Utils.randomString(10)
+      val passwordWrong = nextPassword
 
       val promiseResult: Promise[Unit] = Promise()
       auth.signUp(username, password)
@@ -82,12 +82,12 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
   }
 
   override protected def validationTests(): Unit = {
-    it("when right should succed") {
+    it("when right should succeed") {
       val username = nextUsername
       val password = nextPassword
 
       auth.signUp(username, password)
-        .flatMap(token => auth.validate(token))
+        .flatMap(token => auth.validate(HttpUtils.buildJwtAuthentication(token).get))
         .map(user => assert(user.username == username))
     }
 
@@ -107,7 +107,7 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
       val myToken = nextToken
 
       val promiseResult: Promise[Unit] = Promise()
-      auth.validate(myToken)
+      auth.validate(HttpUtils.buildJwtAuthentication(myToken).get)
         .onComplete({
           case Failure(HTTPException(statusCode, _)) if statusCode == 401 => promiseResult.success(Unit)
           case _ => promiseResult.failure(new Exception)

--- a/core/src/test/scala/it/cwmp/services/wrapper/RoomsApiWrapperTest.scala
+++ b/core/src/test/scala/it/cwmp/services/wrapper/RoomsApiWrapperTest.scala
@@ -17,6 +17,7 @@ class RoomsApiWrapperTest extends RoomsWebServiceTesting with FutureMatchers {
 
   private val apiWrapper = RoomsApiWrapper()
 
+  //noinspection ScalaStyle
   import apiWrapper._
 
   override protected def privateRoomCreationTests(roomName: String, playersNumber: Int): Unit = {
@@ -162,7 +163,7 @@ class RoomsApiWrapperTest extends RoomsWebServiceTesting with FutureMatchers {
       apiCall(0).shouldFailWith[HTTPException]
     }
     it("if room with such players number doesn't exist") {
-      apiCall(20).shouldFailWith[HTTPException]
+      apiCall(TOO_BIG_PLAYERS_NUMBER).shouldFailWith[HTTPException]
     }
   }
 

--- a/services/authentication/src/main/scala/it/cwmp/services/authentication/AuthenticationLocalDAO.scala
+++ b/services/authentication/src/main/scala/it/cwmp/services/authentication/AuthenticationLocalDAO.scala
@@ -80,9 +80,7 @@ case class AuthenticationLocalDAO(override val configurationPath: String = "auth
         connection <- openConnection();
         _ <- connection.updateWithParamsFuture(
           insertNewUserSql, Seq(username, password, "SALT"))
-      ) yield {
-        log.debug("inizialized")
-      }).closeConnections
+      ) yield ()).closeConnections
     }).getOrElse(Future.failed(new IllegalArgumentException()))
   }
 

--- a/services/authentication/src/main/scala/it/cwmp/services/authentication/AuthenticationServiceVerticle.scala
+++ b/services/authentication/src/main/scala/it/cwmp/services/authentication/AuthenticationServiceVerticle.scala
@@ -33,7 +33,7 @@ case class AuthenticationServiceVerticle() extends VertxServer with Logging {
   private def handlerSignUp: Handler[RoutingContext] = implicit routingContext => {
     log.debug("Received sign up request.")
     (for (
-      authorizationHeader <- request.getAuthentication;
+      authorizationHeader <- request.getAuthenticationHeader;
       (username, password) <- HttpUtils.readBasicAuthentication(authorizationHeader)
     ) yield {
       storageFuture flatMap (_.signUpFuture(username, password)) onComplete {
@@ -50,7 +50,7 @@ case class AuthenticationServiceVerticle() extends VertxServer with Logging {
   private def handlerSignOut: Handler[RoutingContext] = implicit routingContext => {
     log.debug("Received sign out request.")
     (for (
-      authorizationHeader <- request.getAuthentication;
+      authorizationHeader <- request.getAuthenticationHeader;
       token <- HttpUtils.readJwtAuthentication(authorizationHeader);
       username <- JwtUtils.decodeUsernameToken(token)
     ) yield {
@@ -67,7 +67,7 @@ case class AuthenticationServiceVerticle() extends VertxServer with Logging {
   private def handlerLogin: Handler[RoutingContext] = implicit routingContext => {
     log.debug("Received login request.")
     (for (
-      authorizationHeader <- request.getAuthentication;
+      authorizationHeader <- request.getAuthenticationHeader;
       (username, password) <- HttpUtils.readBasicAuthentication(authorizationHeader)
     ) yield {
       storageFuture flatMap (_.loginFuture(username, password)) onComplete {
@@ -84,7 +84,7 @@ case class AuthenticationServiceVerticle() extends VertxServer with Logging {
   private def handlerValidation: Handler[RoutingContext] = implicit routingContext => {
     log.debug("Received token validation request.")
     (for (
-      authorizationHeader <- request.getAuthentication;
+      authorizationHeader <- request.getAuthenticationHeader;
       token <- HttpUtils.readJwtAuthentication(authorizationHeader);
       username <- JwtUtils.decodeUsernameToken(token)
     ) yield {

--- a/services/authentication/src/test/scala/it/cwmp/services/authentication/AuthenticationServiceVerticleTest.scala
+++ b/services/authentication/src/test/scala/it/cwmp/services/authentication/AuthenticationServiceVerticleTest.scala
@@ -17,7 +17,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
     .setDefaultPort(DEFAULT_PORT)
     .setKeepAlive(false)
 
-  override protected def singupTests(): Unit = {
+  override protected def singUpTests(): Unit = {
     it("when right should succed") {
       val username = nextUsername
       val password = nextPassword
@@ -57,7 +57,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
     }
   }
 
-  override protected def signoutTests(): Unit = {
+  override protected def signOutTests(): Unit = {
     // TODO implement
   }
 

--- a/services/authentication/src/test/scala/it/cwmp/services/testing/authentication/AuthenticationTesting.scala
+++ b/services/authentication/src/test/scala/it/cwmp/services/testing/authentication/AuthenticationTesting.scala
@@ -30,16 +30,16 @@ abstract class AuthenticationTesting extends VertxTest with Matchers {
   protected val invalidToken: String = "INVALID"
 
 
-  protected def singupTests()
+  protected def singUpTests()
 
   describe("Sign up") {
-    singupTests()
+    singUpTests()
   }
 
-  protected def signoutTests()
+  protected def signOutTests()
 
   describe("Sign out") {
-    signoutTests()
+    signOutTests()
   }
 
   protected def loginTests()


### PR DESCRIPTION
1. The RoomsService to be extraneous from which is the authentication process doesn't know how authentication header of requests is built;
1. So when the RoomsService (or in general a Server) sends a request, this header should placed as is in header of the request and the authentication "part" should manage this;
1. In code there were a part where The ApiWrapper for authentication expected a token (that external services cannot unwrap) when it was passed the entire "authorization header".
1. Now ApiWrapper can manage external services requests, and internally unwraps token for Authentication service.