### PR TITLE
[SPRINT5] Modified .gitignore to ignore all .iml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,7 @@ fabric.properties
 ### Intellij Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
 
-# *.iml
+*.iml
 # modules.xml
 # .idea/misc.xml
 # *.ipr


### PR DESCRIPTION
An .iml file in root folder wasn't ignored; fixed.