### PR TITLE
[SPRINT6] HttpStatusCodes refactoring

### DIFF
--- a/client/src/main/scala/it/cwmp/client/view/FXViewController.scala
+++ b/client/src/main/scala/it/cwmp/client/view/FXViewController.scala
@@ -63,9 +63,8 @@ trait FXViewController {
     val pane: Pane = loader.load()
 
     stage setTitle title
-    stage setResizable false
-    stage.setOnCloseRequest(_ => onCloseAction())
+    stage setOnCloseRequest (_ => onCloseAction())
     stage setScene new Scene(pane)
-    stage.setResizable(false)
+    stage setResizable false
   }
 }

--- a/core/src/main/scala/it/cwmp/services/wrapper/AuthenticationApiWrapper.scala
+++ b/core/src/main/scala/it/cwmp/services/wrapper/AuthenticationApiWrapper.scala
@@ -1,9 +1,11 @@
 package it.cwmp.services.wrapper
 
+import io.netty.handler.codec.http.HttpResponseStatus.{BAD_REQUEST, CREATED, OK}
 import io.vertx.scala.ext.web.client.WebClientOptions
 import it.cwmp.exceptions.HTTPException
 import it.cwmp.model.User
 import it.cwmp.services.authentication.ServerParameters._
+import it.cwmp.utils.Utils.httpStatusNameToCode
 import it.cwmp.utils.{Validation, VertxClient, VertxInstance}
 
 import scala.concurrent.Future
@@ -47,24 +49,24 @@ object AuthenticationApiWrapper {
       client.post(API_SIGNUP)
         .addAuthentication(username, password)
         .sendFuture()
-        .expectStatus(201)
+        .expectStatus(CREATED)
         .map(_.bodyAsString().getOrElse(""))
 
     override def login(username: String, password: String): Future[String] =
       client.get(API_LOGIN)
         .addAuthentication(username, password)
         .sendFuture()
-        .expectStatus(200)
+        .expectStatus(OK)
         .map(_.bodyAsString().getOrElse(""))
 
     override def validate(authenticationHeader: String): Future[User] =
       client.get(API_VALIDATE)
         .addAuthenticationHeader(authenticationHeader)
         .sendFuture()
-        .expectStatus(200)
+        .expectStatus(OK)
         .mapBody {
           case Some(body) => Future.successful(User(body))
-          case _ => Future.failed(HTTPException(400, "Empty body"))
+          case _ => Future.failed(HTTPException(BAD_REQUEST, "Empty body"))
         }
   }
 

--- a/core/src/main/scala/it/cwmp/services/wrapper/RoomsApiWrapper.scala
+++ b/core/src/main/scala/it/cwmp/services/wrapper/RoomsApiWrapper.scala
@@ -1,5 +1,6 @@
 package it.cwmp.services.wrapper
 
+import io.netty.handler.codec.http.HttpResponseStatus.{CREATED, OK}
 import io.vertx.core.buffer.Buffer
 import io.vertx.lang.scala.json.Json
 import io.vertx.scala.ext.web.client.{HttpResponse, WebClientOptions}
@@ -8,6 +9,7 @@ import it.cwmp.model.Room.Converters._
 import it.cwmp.model.{Address, Room}
 import it.cwmp.services.rooms.RoomApiWrapperUtils
 import it.cwmp.services.rooms.ServerParameters._
+import it.cwmp.utils.Utils.httpStatusNameToCode
 import it.cwmp.utils.{VertxClient, VertxInstance}
 
 import scala.concurrent.Future
@@ -144,23 +146,23 @@ object RoomsApiWrapper {
     override def createRoom(roomName: String, playersNumber: Int)
                            (implicit userToken: String): Future[String] =
       createPrivateRoomRequest(roomName, playersNumber)
-        .flatMap(implicit response => handleResponse(Future.successful(response.bodyAsString().get), 201))
+        .flatMap(implicit response => handleResponse(Future.successful(response.bodyAsString().get), CREATED))
 
     override def enterRoom(roomID: String, userAddress: Address, notificationAddress: Address)
                           (implicit userToken: String): Future[Unit] =
       enterPrivateRoomRequest(roomID, userAddress, notificationAddress)
-        .flatMap(implicit response => handleResponse(Future.successful(()), 200))
+        .flatMap(implicit response => handleResponse(Future.successful(()), OK))
 
     override def roomInfo(roomID: String)
                          (implicit userToken: String): Future[Room] =
       privateRoomInfoRequest(roomID)
         .flatMap(implicit response =>
-          handleResponse(Future.successful(Json.fromObjectString(response.bodyAsString().get).toRoom), 200))
+          handleResponse(Future.successful(Json.fromObjectString(response.bodyAsString().get).toRoom), OK))
 
     override def exitRoom(roomID: String)
                          (implicit userToken: String): Future[Unit] =
       exitPrivateRoomRequest(roomID)
-        .flatMap(implicit response => handleResponse(Future.successful(()), 200))
+        .flatMap(implicit response => handleResponse(Future.successful(()), OK))
 
     override def listPublicRooms()(implicit userToken: String): Future[Seq[Room]] =
       listPublicRoomsRequest()
@@ -170,23 +172,23 @@ object RoomsApiWrapper {
               .stream().toArray().toSeq.map(_.toString)
               .map(jsonString => Json.fromObjectString(jsonString).toRoom)
           }
-        }, 200))
+        }, OK))
 
     override def enterPublicRoom(playersNumber: Int, userAddress: Address, notificationAddress: Address)
                                 (implicit userToken: String): Future[Unit] =
       enterPublicRoomRequest(playersNumber, userAddress, notificationAddress)
-        .flatMap(implicit response => handleResponse(Future.successful(()), 200))
+        .flatMap(implicit response => handleResponse(Future.successful(()), OK))
 
     override def publicRoomInfo(playersNumber: Int)
                                (implicit userToken: String): Future[Room] =
       publicRoomInfoRequest(playersNumber)
         .flatMap(implicit response =>
-          handleResponse(Future.successful(Json.fromObjectString(response.bodyAsString().get).toRoom), 200))
+          handleResponse(Future.successful(Json.fromObjectString(response.bodyAsString().get).toRoom), OK))
 
     override def exitPublicRoom(playersNumber: Int)
                                (implicit userToken: String): Future[Unit] =
       exitPublicRoomRequest(playersNumber)
-        .flatMap(implicit response => handleResponse(Future.successful(()), 200))
+        .flatMap(implicit response => handleResponse(Future.successful(()), OK))
 
     /**
       * Utility method to handle the Service response

--- a/core/src/main/scala/it/cwmp/utils/Utils.scala
+++ b/core/src/main/scala/it/cwmp/utils/Utils.scala
@@ -2,6 +2,8 @@ package it.cwmp.utils
 
 import java.text.ParseException
 
+import io.netty.handler.codec.http.HttpResponseStatus
+
 import scala.language.implicitConversions
 
 /**
@@ -38,4 +40,12 @@ object Utils {
     * @return the option of that string
     */
   implicit def stringToOption(string: String): Option[String] = Option(string)
+
+  /**
+    * Implicit conversion of HttpStatus response names to relative codes
+    *
+    * @param httpResponseStatus the httpResponseStatus name to convert
+    * @return the integer representing the httpStatus
+    */
+  implicit def httpStatusNameToCode(httpResponseStatus: HttpResponseStatus): Int = httpResponseStatus.code()
 }

--- a/core/src/main/scala/it/cwmp/utils/VertxServer.scala
+++ b/core/src/main/scala/it/cwmp/utils/VertxServer.scala
@@ -1,12 +1,13 @@
 package it.cwmp.utils
 
 import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST
 import io.vertx.lang.scala.ScalaVerticle
 import io.vertx.scala.core.http.{HttpServer, HttpServerRequest, HttpServerResponse}
 import io.vertx.scala.ext.web.{Router, RoutingContext}
 import it.cwmp.exceptions.HTTPException
 import it.cwmp.model.User
-import it.cwmp.utils.Utils.stringToOption
+import it.cwmp.utils.Utils.{httpStatusNameToCode, stringToOption}
 import it.cwmp.utils.VertxServer.NO_AUTH_HEADER_IN_REQUEST_ERROR
 
 import scala.concurrent.Future
@@ -118,7 +119,7 @@ trait VertxServer extends ScalaVerticle {
                             routingContext: RoutingContext): Future[User] = getAuthenticationHeader match {
       case None =>
         log.warn(NO_AUTH_HEADER_IN_REQUEST_ERROR)
-        Future.failed(HTTPException(400, NO_AUTH_HEADER_IN_REQUEST_ERROR))
+        Future.failed(HTTPException(BAD_REQUEST, NO_AUTH_HEADER_IN_REQUEST_ERROR))
       case Some(authenticationHeader) => strategy.validate(authenticationHeader)
     }
 

--- a/core/src/test/scala/it/cwmp/services/wrapper/AuthenticationApiWrapperTest.scala
+++ b/core/src/test/scala/it/cwmp/services/wrapper/AuthenticationApiWrapperTest.scala
@@ -1,5 +1,6 @@
 package it.cwmp.services.wrapper
 
+import io.netty.handler.codec.http.HttpResponseStatus.{BAD_REQUEST, UNAUTHORIZED}
 import it.cwmp.exceptions.HTTPException
 import it.cwmp.services.testing.authentication.AuthenticationWebServiceTesting
 import it.cwmp.utils.HttpUtils
@@ -24,8 +25,7 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
       val username = nextUsername
       val password = nextPassword
 
-      auth.signUp(username, password)
-        .map(res => res shouldNot be(""))
+      auth.signUp(username, password) map (_ shouldNot be(""))
     }
 
     it("when username already exist should fail") {
@@ -36,7 +36,7 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
       auth.signUp(username, password)
         .flatMap(_ => auth.signUp(username, password))
         .onComplete({
-          case Failure(HTTPException(statusCode, _)) if statusCode == 400 => promiseResult.success(Unit)
+          case Failure(HTTPException(statusCode, _)) if statusCode == BAD_REQUEST.code() => promiseResult.success(())
           case _ => promiseResult.failure(new Exception)
         })
       promiseResult.future.map(_ => succeed)
@@ -54,7 +54,7 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
 
       auth.signUp(username, password)
         .flatMap(_ => auth.login(username, password))
-        .map(res => res shouldNot be(""))
+        .map(_ shouldNot be(""))
     }
 
     it("when user does not exists should fail") {
@@ -64,7 +64,7 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
       val promiseResult: Promise[Unit] = Promise()
       auth.login(username, password)
         .onComplete({
-          case Failure(HTTPException(statusCode, _)) if statusCode == 401 => promiseResult.success(Unit)
+          case Failure(HTTPException(statusCode, _)) if statusCode == UNAUTHORIZED.code() => promiseResult.success(())
           case _ => promiseResult.failure(new Exception)
         })
       promiseResult.future.map(_ => succeed)
@@ -79,7 +79,7 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
       auth.signUp(username, password)
         .flatMap(_ => auth.login(username, passwordWrong))
         .onComplete({
-          case Failure(HTTPException(statusCode, _)) if statusCode == 401 => promiseResult.success(Unit)
+          case Failure(HTTPException(statusCode, _)) if statusCode == UNAUTHORIZED.code() => promiseResult.success(())
           case _ => promiseResult.failure(new Exception)
         })
       promiseResult.future.map(_ => succeed)
@@ -102,7 +102,7 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
       val promiseResult: Promise[Unit] = Promise()
       auth.validate(myToken)
         .onComplete({
-          case Failure(HTTPException(statusCode, _)) if statusCode == 400 => promiseResult.success(Unit)
+          case Failure(HTTPException(statusCode, _)) if statusCode == BAD_REQUEST.code() => promiseResult.success(())
           case _ => promiseResult.failure(new Exception)
         })
       promiseResult.future.map(_ => succeed)
@@ -114,7 +114,7 @@ class AuthenticationApiWrapperTest extends AuthenticationWebServiceTesting {
       val promiseResult: Promise[Unit] = Promise()
       auth.validate(myAuthHeader)
         .onComplete({
-          case Failure(HTTPException(statusCode, _)) if statusCode == 401 => promiseResult.success(Unit)
+          case Failure(HTTPException(statusCode, _)) if statusCode == UNAUTHORIZED.code() => promiseResult.success(())
           case _ => promiseResult.failure(new Exception)
         })
       promiseResult.future.map(_ => succeed)

--- a/services/authentication/src/main/scala/it/cwmp/services/authentication/AuthenticationLocalDAO.scala
+++ b/services/authentication/src/main/scala/it/cwmp/services/authentication/AuthenticationLocalDAO.scala
@@ -81,7 +81,7 @@ case class AuthenticationLocalDAO(override val configurationPath: String = "auth
         _ <- connection.updateWithParamsFuture(
           insertNewUserSql, Seq(username, password, "SALT"))
       ) yield ()).closeConnections
-    }).getOrElse(Future.failed(new IllegalArgumentException()))
+    }).getOrElse(Future.failed(new IllegalArgumentException(USERNAME_OR_PASSWORD_NOT_PROVIDED_ERROR)))
   }
 
   override def signOutFuture(usernameP: String): Future[Unit] = {
@@ -96,7 +96,7 @@ case class AuthenticationLocalDAO(override val configurationPath: String = "auth
         connection <- openConnection();
         result <- connection.updateWithParamsFuture(signOutUserSql, Seq(username)) if result.getUpdated > 0
       ) yield ()).closeConnections
-    }).getOrElse(Future.failed(new IllegalArgumentException()))
+    }).getOrElse(Future.failed(new IllegalArgumentException(USERNAME_NOT_PROVIDED_ERROR)))
   }
 
   override def loginFuture(usernameP: String, passwordP: String): Future[Unit] = {
@@ -112,7 +112,7 @@ case class AuthenticationLocalDAO(override val configurationPath: String = "auth
         connection <- openConnection();
         result <- connection.queryWithParamsFuture(loginUserSql, Seq(username, password)) if result.getResults.nonEmpty
       ) yield ()).closeConnections
-    }).getOrElse(Future.failed(new IllegalArgumentException()))
+    }).getOrElse(Future.failed(new IllegalArgumentException(USERNAME_OR_PASSWORD_NOT_PROVIDED_ERROR)))
   }
 
   override def existsFuture(usernameP: String): Future[Unit] = {
@@ -127,7 +127,7 @@ case class AuthenticationLocalDAO(override val configurationPath: String = "auth
         connection <- openConnection();
         result <- connection.queryWithParamsFuture(existFutureUserSql, Seq(username)) if result.getResults.nonEmpty
       ) yield ()).closeConnections
-    }).getOrElse(Future.failed(new IllegalArgumentException()))
+    }).getOrElse(Future.failed(new IllegalArgumentException(USERNAME_NOT_PROVIDED_ERROR)))
   }
 }
 
@@ -135,6 +135,9 @@ case class AuthenticationLocalDAO(override val configurationPath: String = "auth
   * Companion Object
   */
 object AuthenticationLocalDAO {
+
+  private val USERNAME_OR_PASSWORD_NOT_PROVIDED_ERROR = "Username or password not provided!"
+  private val USERNAME_NOT_PROVIDED_ERROR = "Username not provided!"
 
   private val FIELD_AUTH_USERNAME = "auth_username"
   private val FIELD_AUTH_PASSWORD = "auth_password"

--- a/services/authentication/src/main/scala/it/cwmp/services/authentication/AuthenticationServiceVerticle.scala
+++ b/services/authentication/src/main/scala/it/cwmp/services/authentication/AuthenticationServiceVerticle.scala
@@ -1,9 +1,10 @@
 package it.cwmp.services.authentication
 
+import io.netty.handler.codec.http.HttpResponseStatus._
 import io.vertx.core.Handler
 import io.vertx.scala.ext.web.{Router, RoutingContext}
 import it.cwmp.services.authentication.ServerParameters._
-import it.cwmp.utils.Utils.stringToOption
+import it.cwmp.utils.Utils.{httpStatusNameToCode, stringToOption}
 import it.cwmp.utils.{HttpUtils, Logging, VertxServer}
 
 import scala.concurrent.Future
@@ -42,10 +43,10 @@ case class AuthenticationServiceVerticle() extends VertxServer with Logging {
           log.info(s"User $username signed up.")
           JwtUtils
             .encodeUsernameToken(username)
-            .foreach(sendResponse(201, _))
-        case Failure(_) => sendResponse(400)
+            .foreach(sendResponse(CREATED, _))
+        case Failure(_) => sendResponse(BAD_REQUEST)
       }
-    }) orElse Some(sendResponse(400))
+    }) orElse Some(sendResponse(BAD_REQUEST))
   }
 
   private def handlerSignOut: Handler[RoutingContext] = implicit routingContext => {
@@ -59,10 +60,10 @@ case class AuthenticationServiceVerticle() extends VertxServer with Logging {
       storageFuture.map(_.signOutFuture(username).onComplete {
         case Success(_) =>
           log.info(s"User $username signed out.")
-          sendResponse(202)
-        case Failure(_) => sendResponse(401)
+          sendResponse(ACCEPTED)
+        case Failure(_) => sendResponse(UNAUTHORIZED)
       })
-    }) orElse Some(sendResponse(400))
+    }) orElse Some(sendResponse(BAD_REQUEST))
   }
 
   private def handlerLogin: Handler[RoutingContext] = implicit routingContext => {
@@ -76,10 +77,10 @@ case class AuthenticationServiceVerticle() extends VertxServer with Logging {
           log.info(s"User $username logged in.")
           JwtUtils
             .encodeUsernameToken(username)
-            .foreach(sendResponse(200, _))
-        case Failure(_) => sendResponse(401)
+            .foreach(sendResponse(OK, _))
+        case Failure(_) => sendResponse(UNAUTHORIZED)
       }
-    }) orElse Some(sendResponse(400))
+    }) orElse Some(sendResponse(BAD_REQUEST))
   }
 
   private def handlerValidation: Handler[RoutingContext] = implicit routingContext => {
@@ -93,9 +94,9 @@ case class AuthenticationServiceVerticle() extends VertxServer with Logging {
       storageFuture.map(_.existsFuture(username).onComplete {
         case Success(_) =>
           log.info(s"Token validation for $username successful")
-          sendResponse(200, username)
-        case Failure(_) => sendResponse(401)
+          sendResponse(OK, username)
+        case Failure(_) => sendResponse(UNAUTHORIZED)
       })
-    }) orElse Some(sendResponse(400))
+    }) orElse Some(sendResponse(BAD_REQUEST))
   }
 }

--- a/services/authentication/src/test/scala/it/cwmp/services/authentication/AuthenticationServiceVerticleTest.scala
+++ b/services/authentication/src/test/scala/it/cwmp/services/authentication/AuthenticationServiceVerticleTest.scala
@@ -1,9 +1,11 @@
 package it.cwmp.services.authentication
 
+import io.netty.handler.codec.http.HttpResponseStatus.{BAD_REQUEST, CREATED, OK, UNAUTHORIZED}
 import io.vertx.scala.ext.web.client.WebClientOptions
 import it.cwmp.services.authentication.ServerParameters._
 import it.cwmp.services.testing.authentication.AuthenticationWebServiceTesting
 import it.cwmp.testing.{FutureMatchers, HttpMatchers}
+import it.cwmp.utils.Utils.httpStatusNameToCode
 import it.cwmp.utils.VertxClient
 
 /**
@@ -18,20 +20,20 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
     .setKeepAlive(false)
 
   override protected def singUpTests(): Unit = {
-    it("when right should succed") {
+    it("when right should succeed") {
       val username = nextUsername
       val password = nextPassword
 
       client.post(API_SIGNUP)
         .addAuthentication(username, password)
         .sendFuture()
-        .shouldAnswerWith(201, _.exists(body => body.nonEmpty))
+        .shouldAnswerWith(CREATED, _.exists(body => body.nonEmpty))
     }
 
     it("when empty header should fail") {
       client.post(API_SIGNUP)
         .sendFuture()
-        .shouldAnswerWith(400)
+        .shouldAnswerWith(BAD_REQUEST)
     }
 
     it("when invalid header should fail") {
@@ -39,7 +41,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
       client.post(API_SIGNUP)
         .addAuthentication(token)
         .sendFuture()
-        .shouldAnswerWith(400)
+        .shouldAnswerWith(BAD_REQUEST)
     }
 
     it("when username already exist should fail") {
@@ -53,7 +55,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
           client.post(API_SIGNUP)
             .addAuthentication(username, password)
             .sendFuture())
-        .shouldAnswerWith(400)
+        .shouldAnswerWith(BAD_REQUEST)
     }
   }
 
@@ -62,7 +64,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
   }
 
   override protected def loginTests(): Unit = {
-    it("when right should succed") {
+    it("when right should succeed") {
       val username = nextUsername
       val password = nextPassword
 
@@ -73,13 +75,13 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
           client.get(API_LOGIN)
             .addAuthentication(username, password)
             .sendFuture())
-        .shouldAnswerWith(200, _.exists(body => body.nonEmpty))
+        .shouldAnswerWith(OK, _.exists(body => body.nonEmpty))
     }
 
     it("when empty header should fail") {
       client.get(API_LOGIN)
         .sendFuture()
-        .shouldAnswerWith(400)
+        .shouldAnswerWith(BAD_REQUEST)
     }
 
     it("when invalid header should fail") {
@@ -87,7 +89,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
       client.get(API_LOGIN)
         .addAuthentication(token)
         .sendFuture()
-        .shouldAnswerWith(400)
+        .shouldAnswerWith(BAD_REQUEST)
     }
 
     it("when user does not exists should fail") {
@@ -97,7 +99,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
       client.get(API_LOGIN)
         .addAuthentication(username, password)
         .sendFuture()
-        .shouldAnswerWith(401)
+        .shouldAnswerWith(UNAUTHORIZED)
     }
 
     it("when password is wrong should fail") {
@@ -112,7 +114,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
           client.get(API_LOGIN)
             .addAuthentication(username, passwordWrong)
             .sendFuture())
-        .shouldAnswerWith(401)
+        .shouldAnswerWith(UNAUTHORIZED)
     }
   }
 
@@ -128,13 +130,13 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
           client.get(API_VALIDATE)
             .addAuthentication(response.bodyAsString().get)
             .sendFuture())
-        .shouldAnswerWith(200, _.exists(body => body.nonEmpty))
+        .shouldAnswerWith(OK, _.exists(body => body.nonEmpty))
     }
 
     it("when missing token should fail") {
       client.get(API_VALIDATE)
         .sendFuture()
-        .map(res => res statusCode() should equal(400))
+        .map(res => res statusCode() should equal(BAD_REQUEST))
     }
 
     it("when invalid token should fail") {
@@ -143,7 +145,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
       client.get(API_VALIDATE)
         .addAuthentication(myToken)
         .sendFuture()
-        .shouldAnswerWith(400)
+        .shouldAnswerWith(BAD_REQUEST)
     }
 
     it("when unauthorized token should fail") {
@@ -152,7 +154,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
       client.get(API_VALIDATE)
         .addAuthentication(myToken)
         .sendFuture()
-        .shouldAnswerWith(401)
+        .shouldAnswerWith(UNAUTHORIZED)
     }
   }
 }

--- a/services/authentication/src/test/scala/it/cwmp/services/authentication/AuthenticationServiceVerticleTest.scala
+++ b/services/authentication/src/test/scala/it/cwmp/services/authentication/AuthenticationServiceVerticleTest.scala
@@ -27,7 +27,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
       client.post(API_SIGNUP)
         .addAuthentication(username, password)
         .sendFuture()
-        .shouldAnswerWith(CREATED, _.exists(body => body.nonEmpty))
+        .shouldAnswerWith(CREATED, _.exists(_.nonEmpty))
     }
 
     it("when empty header should fail") {
@@ -75,7 +75,7 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
           client.get(API_LOGIN)
             .addAuthentication(username, password)
             .sendFuture())
-        .shouldAnswerWith(OK, _.exists(body => body.nonEmpty))
+        .shouldAnswerWith(OK, _.exists(_.nonEmpty))
     }
 
     it("when empty header should fail") {
@@ -130,13 +130,11 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
           client.get(API_VALIDATE)
             .addAuthentication(response.bodyAsString().get)
             .sendFuture())
-        .shouldAnswerWith(OK, _.exists(body => body.nonEmpty))
+        .shouldAnswerWith(OK, _.exists(_.nonEmpty))
     }
 
     it("when missing token should fail") {
-      client.get(API_VALIDATE)
-        .sendFuture()
-        .map(res => res statusCode() should equal(BAD_REQUEST))
+      client.get(API_VALIDATE).sendFuture() shouldAnswerWith BAD_REQUEST
     }
 
     it("when invalid token should fail") {

--- a/services/authentication/src/test/scala/it/cwmp/services/authentication/AuthenticationServiceVerticleTest.scala
+++ b/services/authentication/src/test/scala/it/cwmp/services/authentication/AuthenticationServiceVerticleTest.scala
@@ -31,31 +31,22 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
     }
 
     it("when empty header should fail") {
-      client.post(API_SIGNUP)
-        .sendFuture()
-        .shouldAnswerWith(BAD_REQUEST)
+      client.post(API_SIGNUP) sendFuture() shouldAnswerWith BAD_REQUEST
     }
 
     it("when invalid header should fail") {
-      val token = invalidToken
-      client.post(API_SIGNUP)
-        .addAuthentication(token)
-        .sendFuture()
-        .shouldAnswerWith(BAD_REQUEST)
+      client.post(API_SIGNUP) addAuthentication invalidToken sendFuture() shouldAnswerWith BAD_REQUEST
     }
 
     it("when username already exist should fail") {
       val username = nextUsername
       val password = nextPassword
 
-      client.post(API_SIGNUP)
-        .addAuthentication(username, password)
-        .sendFuture()
-        .flatMap(_ =>
-          client.post(API_SIGNUP)
-            .addAuthentication(username, password)
-            .sendFuture())
-        .shouldAnswerWith(BAD_REQUEST)
+      for (
+        _ <- client.post(API_SIGNUP) addAuthentication(username, password) sendFuture();
+        apiRequest = client.post(API_SIGNUP) addAuthentication(username, password) sendFuture();
+        assertion <- apiRequest shouldAnswerWith BAD_REQUEST
+      ) yield assertion
     }
   }
 
@@ -68,38 +59,26 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
       val username = nextUsername
       val password = nextPassword
 
-      client.post(API_SIGNUP)
-        .addAuthentication(username, password)
-        .sendFuture()
-        .flatMap(_ =>
-          client.get(API_LOGIN)
-            .addAuthentication(username, password)
-            .sendFuture())
-        .shouldAnswerWith(OK, _.exists(_.nonEmpty))
+      for (
+        _ <- client.post(API_SIGNUP) addAuthentication(username, password) sendFuture();
+        apiRequest = client.get(API_LOGIN) addAuthentication(username, password) sendFuture();
+        assertion <- apiRequest shouldAnswerWith(OK, _.exists(_.nonEmpty))
+      ) yield assertion
     }
 
     it("when empty header should fail") {
-      client.get(API_LOGIN)
-        .sendFuture()
-        .shouldAnswerWith(BAD_REQUEST)
+      client.get(API_LOGIN) sendFuture() shouldAnswerWith BAD_REQUEST
     }
 
     it("when invalid header should fail") {
-      val token = invalidToken
-      client.get(API_LOGIN)
-        .addAuthentication(token)
-        .sendFuture()
-        .shouldAnswerWith(BAD_REQUEST)
+      client.get(API_LOGIN) addAuthentication invalidToken sendFuture() shouldAnswerWith BAD_REQUEST
     }
 
     it("when user does not exists should fail") {
       val username = nextUsername
       val password = nextPassword
 
-      client.get(API_LOGIN)
-        .addAuthentication(username, password)
-        .sendFuture()
-        .shouldAnswerWith(UNAUTHORIZED)
+      client.get(API_LOGIN) addAuthentication(username, password) sendFuture() shouldAnswerWith UNAUTHORIZED
     }
 
     it("when password is wrong should fail") {
@@ -107,14 +86,11 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
       val password = nextPassword
       val passwordWrong = nextPassword
 
-      client.post(API_SIGNUP)
-        .addAuthentication(username, password)
-        .sendFuture()
-        .flatMap(_ =>
-          client.get(API_LOGIN)
-            .addAuthentication(username, passwordWrong)
-            .sendFuture())
-        .shouldAnswerWith(UNAUTHORIZED)
+      for (
+        _ <- client.post(API_SIGNUP) addAuthentication(username, password) sendFuture();
+        apiRequest = client.get(API_LOGIN) addAuthentication(username, passwordWrong) sendFuture();
+        assertion <- apiRequest shouldAnswerWith UNAUTHORIZED
+      ) yield assertion
     }
   }
 
@@ -123,14 +99,11 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
       val username = nextUsername
       val password = nextPassword
 
-      client.post(API_SIGNUP)
-        .addAuthentication(username, password)
-        .sendFuture()
-        .flatMap(response =>
-          client.get(API_VALIDATE)
-            .addAuthentication(response.bodyAsString().get)
-            .sendFuture())
-        .shouldAnswerWith(OK, _.exists(_.nonEmpty))
+      for (
+        response <- client.post(API_SIGNUP) addAuthentication(username, password) sendFuture();
+        apiRequest = client.get(API_VALIDATE) addAuthentication response.bodyAsString().get sendFuture();
+        assertion <- apiRequest shouldAnswerWith(OK, _.exists(_.nonEmpty))
+      ) yield assertion
     }
 
     it("when missing token should fail") {
@@ -138,21 +111,12 @@ class AuthenticationServiceVerticleTest extends AuthenticationWebServiceTesting
     }
 
     it("when invalid token should fail") {
-      val myToken = invalidToken
-
-      client.get(API_VALIDATE)
-        .addAuthentication(myToken)
-        .sendFuture()
-        .shouldAnswerWith(BAD_REQUEST)
+      client.get(API_VALIDATE) addAuthentication invalidToken sendFuture() shouldAnswerWith BAD_REQUEST
     }
 
     it("when unauthorized token should fail") {
       val myToken = nextToken
-
-      client.get(API_VALIDATE)
-        .addAuthentication(myToken)
-        .sendFuture()
-        .shouldAnswerWith(UNAUTHORIZED)
+      client.get(API_VALIDATE) addAuthentication myToken sendFuture() shouldAnswerWith UNAUTHORIZED
     }
   }
 }

--- a/services/room-receiver/src/main/scala/it/cwmp/services/roomreceiver/RoomReceiverServiceVerticle.scala
+++ b/services/room-receiver/src/main/scala/it/cwmp/services/roomreceiver/RoomReceiverServiceVerticle.scala
@@ -1,5 +1,6 @@
 package it.cwmp.services.roomreceiver
 
+import io.netty.handler.codec.http.HttpResponseStatus.{BAD_REQUEST, CREATED}
 import io.vertx.core.Handler
 import io.vertx.core.buffer.Buffer
 import io.vertx.lang.scala.json.JsonObject
@@ -7,7 +8,7 @@ import io.vertx.scala.ext.web.{Router, RoutingContext}
 import it.cwmp.model.Participant
 import it.cwmp.model.Participant.Converters._
 import it.cwmp.services.roomreceiver.ServerParameters._
-import it.cwmp.utils.Utils.stringToOption
+import it.cwmp.utils.Utils.{httpStatusNameToCode, stringToOption}
 import it.cwmp.utils.{Logging, VertxServer}
 
 /**
@@ -39,10 +40,10 @@ case class RoomReceiverServiceVerticle(token: String, receptionStrategy: List[Pa
           log.debug("Applying reception strategy...")
           receptionStrategy(participants)
           response.endHandler(_ => server.close())
-          sendResponse(201)
+          sendResponse(CREATED)
         case None =>
           log.info("Error: List is invalid.")
-          sendResponse(400, "Invalid parameter: no participant list JSON in body")
+          sendResponse(BAD_REQUEST, "Invalid parameter: no participant list JSON in body")
       })
 
     def extractIncomingParticipantListFromBody(body: Buffer): Option[List[Participant]] = {

--- a/services/room-receiver/src/test/scala/it/cwmp/services/roomreceiver/RoomReceiverServiceVerticleTest.scala
+++ b/services/room-receiver/src/test/scala/it/cwmp/services/roomreceiver/RoomReceiverServiceVerticleTest.scala
@@ -25,27 +25,25 @@ class RoomReceiverServiceVerticleTest extends RoomReceiverWebTesting
     describe("Receiving partecipants list") {
       it("When wrong url should 404") {
         client.post(API_RECEIVE_PARTICIPANTS_URL(wrongToken)).port(port)
-          .sendFuture()
-          .map(res => res statusCode() should equal(404))
+          .sendFuture() shouldAnswerWith 404
       }
 
       it("When right url and empty body should 400") {
         client.post(API_RECEIVE_PARTICIPANTS_URL(rightToken)).port(port)
-          .sendFuture()
-          .map(res => res statusCode() should equal(400))
+          .sendFuture() shouldAnswerWith 400
       }
 
       it("When right url and body should 201") {
         client.post(API_RECEIVE_PARTICIPANTS_URL(rightToken)).port(port)
           .sendJsonFuture(participants.foldLeft(Json emptyArr())(_ add _.toJson))
-          .map(res => res statusCode() should equal(201))
+          .shouldAnswerWith(201)
       }
 
       it("When right url and body should obtain the correct list") {
         client.post(API_RECEIVE_PARTICIPANTS_URL(rightToken)).port(port)
           .sendJsonFuture(participants.foldLeft(Json emptyArr())(_ add _.toJson))
           .flatMap(_ => participantsPromise.future)
-          .map(l => l should equal(participants))
+          .map(_ should equal(participants))
       }
 
       it("When right, after response should close") {
@@ -54,7 +52,7 @@ class RoomReceiverServiceVerticleTest extends RoomReceiverWebTesting
           .transform({
             case Success(res) if res.statusCode() == 201 => Success(Unit)
             case Success(res) => Failure(HTTPException(res.statusCode(), res.statusMessage()))
-            case Failure(f) => Failure(f)
+            case failure@Failure(_) => failure
           })
           .flatMap(_ => client.post(API_RECEIVE_PARTICIPANTS_URL(rightToken))
             .sendFuture()

--- a/services/room-receiver/src/test/scala/it/cwmp/services/roomreceiver/RoomReceiverServiceVerticleTest.scala
+++ b/services/room-receiver/src/test/scala/it/cwmp/services/roomreceiver/RoomReceiverServiceVerticleTest.scala
@@ -1,5 +1,6 @@
 package it.cwmp.services.roomreceiver
 
+import io.netty.handler.codec.http.HttpResponseStatus.{BAD_REQUEST, CREATED, NOT_FOUND}
 import io.vertx.lang.scala.json.Json
 import io.vertx.scala.ext.web.client.WebClientOptions
 import it.cwmp.exceptions.HTTPException
@@ -7,6 +8,7 @@ import it.cwmp.model.Participant.Converters._
 import it.cwmp.services.roomreceiver.ServerParameters._
 import it.cwmp.services.testing.roomreceiver.RoomReceiverWebTesting
 import it.cwmp.testing.{FutureMatchers, HttpMatchers}
+import it.cwmp.utils.Utils.httpStatusNameToCode
 import it.cwmp.utils.VertxClient
 
 import scala.util.{Failure, Success}
@@ -23,20 +25,20 @@ class RoomReceiverServiceVerticleTest extends RoomReceiverWebTesting
 
   describe("RoomReceiver") {
     describe("Receiving partecipants list") {
-      it("When wrong url should 404") {
+      it("When wrong url should NOT_FOUND") {
         client.post(API_RECEIVE_PARTICIPANTS_URL(wrongToken)).port(port)
-          .sendFuture() shouldAnswerWith 404
+          .sendFuture() shouldAnswerWith NOT_FOUND
       }
 
-      it("When right url and empty body should 400") {
+      it("When right url and empty body should BAD_REQUEST") {
         client.post(API_RECEIVE_PARTICIPANTS_URL(rightToken)).port(port)
-          .sendFuture() shouldAnswerWith 400
+          .sendFuture() shouldAnswerWith BAD_REQUEST
       }
 
-      it("When right url and body should 201") {
+      it("When right url and body should CREATED") {
         client.post(API_RECEIVE_PARTICIPANTS_URL(rightToken)).port(port)
           .sendJsonFuture(participants.foldLeft(Json emptyArr())(_ add _.toJson))
-          .shouldAnswerWith(201)
+          .shouldAnswerWith(CREATED)
       }
 
       it("When right url and body should obtain the correct list") {
@@ -50,7 +52,7 @@ class RoomReceiverServiceVerticleTest extends RoomReceiverWebTesting
         client.post(API_RECEIVE_PARTICIPANTS_URL(rightToken)).port(port)
           .sendFuture()
           .transform({
-            case Success(res) if res.statusCode() == 201 => Success(Unit)
+            case Success(res) if res.statusCode() == CREATED.code() => Success(())
             case Success(res) => Failure(HTTPException(res.statusCode(), res.statusMessage()))
             case failure@Failure(_) => failure
           })

--- a/services/rooms/src/main/scala/it/cwmp/services/rooms/RoomsServiceVerticle.scala
+++ b/services/rooms/src/main/scala/it/cwmp/services/rooms/RoomsServiceVerticle.scala
@@ -1,5 +1,6 @@
 package it.cwmp.services.rooms
 
+import io.netty.handler.codec.http.HttpResponseStatus.{BAD_REQUEST, CREATED, NOT_FOUND, OK}
 import io.vertx.core.Handler
 import io.vertx.core.buffer.Buffer
 import io.vertx.lang.scala.json.Json
@@ -10,7 +11,7 @@ import it.cwmp.model.{Address, Participant, Room, User}
 import it.cwmp.services.rooms.RoomsServiceVerticle.{INVALID_PARAMETER_ERROR, _}
 import it.cwmp.services.rooms.ServerParameters._
 import it.cwmp.services.wrapper.RoomReceiverApiWrapper
-import it.cwmp.utils.Utils.stringToOption
+import it.cwmp.utils.Utils.{httpStatusNameToCode, stringToOption}
 import it.cwmp.utils.{Logging, Validation, VertxServer}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -57,11 +58,11 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
         extractIncomingRoomFromBody(body) match {
           case Some((roomName, neededPlayers)) =>
             daoFuture.map(_.createRoom(roomName, neededPlayers).onComplete {
-              failureHandler orElse successHandler(generatedID => sendResponse(201, generatedID))
+              failureHandler orElse successHandler(generatedID => sendResponse(CREATED, generatedID))
             })
           case None =>
             log.warn("Request body for room creation is required!")
-            sendResponse(400, s"$INVALID_PARAMETER_ERROR no Room JSON in body")
+            sendResponse(BAD_REQUEST, s"$INVALID_PARAMETER_ERROR no Room JSON in body")
         }))
 
     def extractIncomingRoomFromBody(body: Buffer): Option[(String, Int)] = {
@@ -86,12 +87,12 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
         (getRequestParameter(Room.FIELD_IDENTIFIER), extractAddressesFromBody(body)) match {
           case (Some(roomID), Some(addresses)) =>
             daoFuture.map(implicit dao => dao.enterRoom(roomID)(Participant(user.username, addresses._1.address), addresses._2).onComplete {
-              failureHandler orElse successHandler(_ => handlePrivateRoomFilling(roomID) map (_ => sendResponse(200)))
+              failureHandler orElse successHandler(_ => handlePrivateRoomFilling(roomID) map (_ => sendResponse(OK)))
             })
 
           case _ =>
             log.warn("Player and notification address are required for entering a room!")
-            sendResponse(400, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_IDENTIFIER} or ${Address.FIELD_ADDRESS}")
+            sendResponse(BAD_REQUEST, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_IDENTIFIER} or ${Address.FIELD_ADDRESS}")
         }
       }))
   }
@@ -105,9 +106,9 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
       getRequestParameter(Room.FIELD_IDENTIFIER) match {
         case Some(roomId) =>
           daoFuture.map(_.roomInfo(roomId).map(_._1).onComplete {
-            failureHandler orElse successHandler(room => sendResponse(200, room.toJson.encode()))
+            failureHandler orElse successHandler(room => sendResponse(OK, room.toJson.encode()))
           })
-        case None => sendResponse(400, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_IDENTIFIER}")
+        case None => sendResponse(BAD_REQUEST, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_IDENTIFIER}")
       }
     })
   }
@@ -121,9 +122,9 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
       getRequestParameter(Room.FIELD_IDENTIFIER) match {
         case Some(roomId) =>
           daoFuture.map(_.exitRoom(roomId).onComplete {
-            failureHandler orElse successHandler(_ => sendResponse(200))
+            failureHandler orElse successHandler(_ => sendResponse(OK))
           })
-        case None => sendResponse(400, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_IDENTIFIER}")
+        case None => sendResponse(BAD_REQUEST, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_IDENTIFIER}")
       }
     })
   }
@@ -136,7 +137,7 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
     request.checkAuthenticationOrReject.map(_ =>
       daoFuture.map(_.listPublicRooms().onComplete {
         failureHandler orElse
-          successHandler(rooms => sendResponse(200, rooms.foldLeft(Json emptyArr())(_ add _.toJson) encode()))
+          successHandler(rooms => sendResponse(OK, rooms.foldLeft(Json emptyArr())(_ add _.toJson) encode()))
       }))
   }
 
@@ -155,12 +156,12 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
           case (Some(playersNumber), Some(addresses)) =>
             daoFuture.map(implicit dao => dao.enterPublicRoom(playersNumber)(Participant(user.username, addresses._1.address), addresses._2)
               .onComplete {
-                failureHandler orElse successHandler(_ => handlePublicRoomFilling(playersNumber) map (_ => sendResponse(200)))
+                failureHandler orElse successHandler(_ => handlePublicRoomFilling(playersNumber) map (_ => sendResponse(OK)))
               })
 
           case _ =>
             log.warn("The number of players in url and player/notification address in body are required for public room entering")
-            sendResponse(400, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_NEEDED_PLAYERS} or ${Address.FIELD_ADDRESS}")
+            sendResponse(BAD_REQUEST, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_NEEDED_PLAYERS} or ${Address.FIELD_ADDRESS}")
         }
       }))
   }
@@ -177,11 +178,11 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
       }) match {
         case Some(playersNumber) =>
           daoFuture.map(_.publicRoomInfo(playersNumber).map(_._1).onComplete {
-            failureHandler orElse { case Success(room) => sendResponse(200, room.toJson.encode()) }
+            failureHandler orElse { case Success(room) => sendResponse(OK, room.toJson.encode()) }
           })
         case None =>
           log.warn("The number of players in url is required for public room info retrieval")
-          sendResponse(400, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_NEEDED_PLAYERS}")
+          sendResponse(BAD_REQUEST, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_NEEDED_PLAYERS}")
       }
     })
   }
@@ -198,11 +199,11 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
       }) match {
         case Some(roomId) =>
           daoFuture.map(_.exitPublicRoom(roomId).onComplete {
-            failureHandler orElse successHandler(_ => sendResponse(200))
+            failureHandler orElse successHandler(_ => sendResponse(OK))
           })
         case None =>
           log.warn("The number of players in url is required for public room exiting")
-          sendResponse(400, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_NEEDED_PLAYERS}")
+          sendResponse(BAD_REQUEST, s"$INVALID_PARAMETER_ERROR ${Room.FIELD_NEEDED_PLAYERS}")
       }
     })
   }
@@ -218,7 +219,7 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
                                        executionContext: ExecutionContext): Future[Unit] = {
     handleRoomFilling(roomInformationFuture = roomDAO.roomInfo(roomID),
       onRetrievedRoomAction = (roomDAO deleteRoom roomID)
-        .map(_ => sendResponse(200)))(communicationStrategy, executionContext)
+        .map(_ => sendResponse(OK)))(communicationStrategy, executionContext)
   }
 
   /**
@@ -231,7 +232,7 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
                                       executionContext: ExecutionContext): Future[Unit] = {
     handleRoomFilling(roomInformationFuture = roomDAO.publicRoomInfo(playersNumber),
       onRetrievedRoomAction = (roomDAO deleteAndRecreatePublicRoom playersNumber)
-        .map(_ => sendResponse(200)))(communicationStrategy, executionContext)
+        .map(_ => sendResponse(OK)))(communicationStrategy, executionContext)
   }
 
   /**
@@ -278,8 +279,8 @@ class RoomsServiceVerticle(implicit val validationStrategy: Validation[String, U
     * @return the common handler for failures in this service
     */
   private def failureHandler(implicit routingContext: RoutingContext): PartialFunction[Try[_], Unit] = {
-    case Failure(ex: NoSuchElementException) => sendResponse(404, ex.getMessage)
-    case Failure(ex) => sendResponse(400, ex.getMessage)
+    case Failure(ex: NoSuchElementException) => sendResponse(NOT_FOUND, ex.getMessage)
+    case Failure(ex) => sendResponse(BAD_REQUEST, ex.getMessage)
   }
 
   /**

--- a/services/rooms/src/test/scala/it/cwmp/services/rooms/RoomsServiceVerticleTest.scala
+++ b/services/rooms/src/test/scala/it/cwmp/services/rooms/RoomsServiceVerticleTest.scala
@@ -1,5 +1,6 @@
 package it.cwmp.services.rooms
 
+import io.netty.handler.codec.http.HttpResponseStatus._
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.HttpMethod._
 import io.vertx.scala.ext.web.client.{HttpResponse, WebClientOptions}
@@ -8,6 +9,7 @@ import it.cwmp.model.Room.Converters._
 import it.cwmp.services.rooms.ServerParameters._
 import it.cwmp.testing.HttpMatchers
 import it.cwmp.testing.rooms.RoomsWebServiceTesting
+import it.cwmp.utils.Utils.httpStatusNameToCode
 import it.cwmp.utils.VertxClient
 
 import scala.concurrent.Future
@@ -28,21 +30,21 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
 
     it("should succeed when the user is authenticated and input is valid") {
       for (response <- createPrivateRoomRequest(roomName, playersNumber);
-           assertion <- assert(response.statusCode() == 201 && response.bodyAsString().isDefined)) yield assertion
+           assertion <- assert(response.statusCode() == CREATED.code() && response.bodyAsString().isDefined)) yield assertion
     }
 
     describe("should fail") {
       it("if no room is sent with request") {
-        client.post(creationApi).addAuthentication.sendFuture() shouldAnswerWith 400
+        client.post(creationApi).addAuthentication.sendFuture() shouldAnswerWith BAD_REQUEST
       }
       it("if body is malformed") {
-        client.post(creationApi).addAuthentication.sendJsonFuture("Ciao") shouldAnswerWith 400
+        client.post(creationApi).addAuthentication.sendJsonFuture("Ciao") shouldAnswerWith BAD_REQUEST
       }
       it("if the roomName sent is empty") {
-        createPrivateRoomRequest("", playersNumber) shouldAnswerWith 400
+        createPrivateRoomRequest("", playersNumber) shouldAnswerWith BAD_REQUEST
       }
       it("if the playersNumber isn't valid") {
-        createPrivateRoomRequest(roomName, 0) shouldAnswerWith 400
+        createPrivateRoomRequest(roomName, 0) shouldAnswerWith BAD_REQUEST
       }
     }
   }
@@ -50,7 +52,7 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
   override protected def privateRoomEnteringTests(roomName: String, playersNumber: Int): Unit = {
     it("should succeed when the user is authenticated, input is valid and room non full") {
       for (roomID <- createAPrivateRoomAndGetID(roomName, playersNumber);
-           assertion <- enterPrivateRoomRequest(roomID, participantList.head, notificationAddress) shouldAnswerWith 200;
+           assertion <- enterPrivateRoomRequest(roomID, participantList.head, notificationAddress) shouldAnswerWith OK;
            _ <- cleanUpRoom(roomID)) yield assertion
     }
 
@@ -58,15 +60,15 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
       onWrongRoomID(enterPrivateRoomRequest(_, participantList.head, notificationAddress))
 
       it("if address not provided") {
-        client.put(API_ENTER_PRIVATE_ROOM_URL).addAuthentication.sendFuture() shouldAnswerWith 400
+        client.put(API_ENTER_PRIVATE_ROOM_URL).addAuthentication.sendFuture() shouldAnswerWith BAD_REQUEST
       }
       it("if address message malformed") {
-        client.put(API_ENTER_PRIVATE_ROOM_URL).addAuthentication.sendJsonFuture("Ciao") shouldAnswerWith 400
+        client.put(API_ENTER_PRIVATE_ROOM_URL).addAuthentication.sendJsonFuture("Ciao") shouldAnswerWith BAD_REQUEST
       }
       it("if user is already inside a room") {
         for (roomID <- createAPrivateRoomAndGetID(roomName, playersNumber);
              _ <- enterPrivateRoomRequest(roomID, participantList.head, notificationAddress);
-             assertion <- enterPrivateRoomRequest(roomID, participantList.head, notificationAddress) shouldAnswerWith 400;
+             assertion <- enterPrivateRoomRequest(roomID, participantList.head, notificationAddress) shouldAnswerWith BAD_REQUEST;
              _ <- cleanUpRoom(roomID)) yield assertion
       }
       it("if the room was already filled") {
@@ -74,7 +76,7 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
         for (roomID <- createAPrivateRoomAndGetID(roomName, playersNumber);
              _ <- enterPrivateRoomRequest(roomID, participantList.head, notificationAddress);
              _ <- enterPrivateRoomRequest(roomID, participantList(1), notificationAddress)(client, tokenList(1));
-             assertion <- enterPrivateRoomRequest(roomID, participantList(2), notificationAddress)(client, tokenList(2)) shouldAnswerWith 404)
+             assertion <- enterPrivateRoomRequest(roomID, participantList(2), notificationAddress)(client, tokenList(2)) shouldAnswerWith NOT_FOUND)
           yield assertion
       }
     }
@@ -85,7 +87,7 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
       for (roomID <- createAPrivateRoomAndGetID(roomName, playersNumber);
            response <- privateRoomInfoRequest(roomID);
            roomJson = Room(roomID, roomName, playersNumber, Seq()).toJson.encode();
-           assertion <- assert(response.statusCode() == 200 && response.bodyAsString().get == roomJson))
+           assertion <- assert(response.statusCode() == OK.code() && response.bodyAsString().get == roomJson))
         yield assertion
     }
 
@@ -98,14 +100,14 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
     it("should succeed if roomID is correct and user inside") {
       for (roomID <- createAPrivateRoomAndGetID(roomName, playersNumber);
            _ <- enterPrivateRoomRequest(roomID, participantList.head, notificationAddress);
-           assertion <- exitPrivateRoomRequest(roomID) shouldAnswerWith 200) yield assertion
+           assertion <- exitPrivateRoomRequest(roomID) shouldAnswerWith OK) yield assertion
     }
     it("user should not be inside after it") {
       for (roomID <- createAPrivateRoomAndGetID(roomName, playersNumber);
            _ <- enterPrivateRoomRequest(roomID, participantList.head, notificationAddress);
            _ <- exitPrivateRoomRequest(roomID);
            response <- privateRoomInfoRequest(roomID);
-           assertion <- assert(response.statusCode() == 200 && !response.bodyAsString().get.contains(participantList.head.username)))
+           assertion <- assert(response.statusCode() == OK.code() && !response.bodyAsString().get.contains(participantList.head.username)))
         yield assertion
     }
 
@@ -114,13 +116,13 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
 
       it("if user is not inside the room") {
         for (roomID <- createAPrivateRoomAndGetID(roomName, playersNumber);
-             assertion <- exitPrivateRoomRequest(roomID) shouldAnswerWith 400) yield assertion
+             assertion <- exitPrivateRoomRequest(roomID) shouldAnswerWith BAD_REQUEST) yield assertion
       }
       it("if user is inside another room") {
         for (roomID <- createAPrivateRoomAndGetID(roomName, playersNumber);
              otherRoomID <- createAPrivateRoomAndGetID(roomName, playersNumber);
              _ <- enterPrivateRoomRequest(roomID, participantList.head, notificationAddress);
-             assertion <- exitPrivateRoomRequest(otherRoomID) shouldAnswerWith 400;
+             assertion <- exitPrivateRoomRequest(otherRoomID) shouldAnswerWith BAD_REQUEST;
              _ <- cleanUpRoom(roomID)) yield assertion
       }
     }
@@ -129,13 +131,13 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
   override protected def publicRoomEnteringTests(playersNumber: Int): Unit = {
     describe("should succeed") {
       it("if room with such players number exists") {
-        for (assertion <- enterPublicRoomRequest(playersNumber, participantList.head, notificationAddress) shouldAnswerWith 200;
+        for (assertion <- enterPublicRoomRequest(playersNumber, participantList.head, notificationAddress) shouldAnswerWith OK;
              _ <- cleanUpRoom(playersNumber)) yield assertion
       }
       it("and the user should be inside it") {
         for (_ <- enterPublicRoomRequest(playersNumber, participantList.head, notificationAddress);
              response <- publicRoomInfoRequest(playersNumber);
-             assertion <- assert(response.statusCode() == 200 && response.bodyAsString().get.contains(participantList.head.username));
+             assertion <- assert(response.statusCode() == OK.code() && response.bodyAsString().get.contains(participantList.head.username));
              _ <- cleanUpRoom(playersNumber)) yield assertion
       }
       it("even when the room was filled in past") {
@@ -143,7 +145,7 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
              _ <- enterPublicRoomRequest(2, participantList(1), notificationAddress)(client, tokenList(1));
              _ <- enterPublicRoomRequest(2, participantList(2), notificationAddress)(client, tokenList(2));
              response <- publicRoomInfoRequest(2);
-             assertion <- assert(response.statusCode() == 200 &&
+             assertion <- assert(response.statusCode() == OK.code() &&
                !response.bodyAsString().get.contains(participantList.head.username) &&
                !response.bodyAsString().get.contains(participantList(1).username) &&
                response.bodyAsString().get.contains(participantList(2).username));
@@ -155,14 +157,14 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
       onWrongPlayersNumber(enterPublicRoomRequest(_, participantList.head, notificationAddress))
 
       it("if address not provided") {
-        client.put(API_ENTER_PUBLIC_ROOM_URL).addAuthentication.sendFuture() shouldAnswerWith 400
+        client.put(API_ENTER_PUBLIC_ROOM_URL).addAuthentication.sendFuture() shouldAnswerWith BAD_REQUEST
       }
       it("if address message malformed") {
-        client.put(API_ENTER_PUBLIC_ROOM_URL).addAuthentication.sendJsonFuture("Ciao") shouldAnswerWith 400
+        client.put(API_ENTER_PUBLIC_ROOM_URL).addAuthentication.sendJsonFuture("Ciao") shouldAnswerWith BAD_REQUEST
       }
       it("if same user is already inside a room") {
         for (_ <- enterPublicRoomRequest(2, participantList.head, notificationAddress);
-             assertion <- enterPublicRoomRequest(3, participantList.head, notificationAddress) shouldAnswerWith 400;
+             assertion <- enterPublicRoomRequest(3, participantList.head, notificationAddress) shouldAnswerWith BAD_REQUEST;
              _ <- cleanUpRoom(playersNumber)) yield assertion
       }
     }
@@ -171,19 +173,19 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
   override protected def publicRoomListingTests(playersNumber: Int): Unit = {
     it("should be nonEmpty") {
       for (response <- listPublicRoomsRequest();
-           assertion <- assert(response.statusCode() == 200 && response.bodyAsString().get.nonEmpty))
+           assertion <- assert(response.statusCode() == OK.code() && response.bodyAsString().get.nonEmpty))
         yield assertion
     }
   }
 
   override protected def publicRoomInfoRetrievalTests(playersNumber: Int): Unit = {
     it("should succeed if provided playersNumber is correct") {
-      publicRoomInfoRequest(playersNumber) shouldAnswerWith 200
+      publicRoomInfoRequest(playersNumber) shouldAnswerWith OK
     }
     it("should show entered players") {
       for (_ <- enterPublicRoomRequest(playersNumber, participantList.head, notificationAddress);
            response <- publicRoomInfoRequest(playersNumber);
-           assertion <- assert(response.statusCode() == 200 && response.bodyAsString().get.contains(participantList.head.username));
+           assertion <- assert(response.statusCode() == OK.code() && response.bodyAsString().get.contains(participantList.head.username));
            _ <- cleanUpRoom(playersNumber)) yield assertion
     }
 
@@ -195,13 +197,13 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
   override protected def publicRoomExitingTests(playersNumber: Int): Unit = {
     it("should succeed if players number is correct and user is inside") {
       for (_ <- enterPublicRoomRequest(playersNumber, participantList.head, notificationAddress);
-           assertion <- exitPublicRoomRequest(playersNumber) shouldAnswerWith 200) yield assertion
+           assertion <- exitPublicRoomRequest(playersNumber) shouldAnswerWith OK) yield assertion
     }
     it("user should not be inside after it") {
       for (_ <- enterPublicRoomRequest(playersNumber, participantList.head, notificationAddress);
            _ <- exitPublicRoomRequest(playersNumber);
            response <- publicRoomInfoRequest(playersNumber);
-           assertion <- assert(response.statusCode() == 200 && !response.bodyAsString().get.contains(participantList.head.username)))
+           assertion <- assert(response.statusCode() == OK.code() && !response.bodyAsString().get.contains(participantList.head.username)))
         yield assertion
     }
 
@@ -209,11 +211,11 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
       onWrongPlayersNumber(exitPublicRoomRequest)
 
       it("if user is not inside the room") {
-        exitPublicRoomRequest(playersNumber) shouldAnswerWith 400
+        exitPublicRoomRequest(playersNumber) shouldAnswerWith BAD_REQUEST
       }
       it("if user is inside another room") {
         for (_ <- enterPublicRoomRequest(2, participantList.head, notificationAddress);
-             assertion <- exitPublicRoomRequest(3) shouldAnswerWith 400;
+             assertion <- exitPublicRoomRequest(3) shouldAnswerWith BAD_REQUEST;
              _ <- cleanUpRoom(playersNumber)) yield assertion
       }
     }
@@ -235,15 +237,15 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
     describe("should fail") {
       for (apiCall <- roomApiInteractions) {
         it(s"if token not provided, doing ${apiCall._1.toString} on ${apiCall._2}") {
-          client.request(apiCall._1, apiCall._2).sendFuture() shouldAnswerWith 400
+          client.request(apiCall._1, apiCall._2).sendFuture() shouldAnswerWith BAD_REQUEST
         }
         it(s"if token wrong, doing ${apiCall._1.toString} on ${apiCall._2}") {
-          client.request(apiCall._1, apiCall._2).addAuthentication("token").sendFuture() shouldAnswerWith 401
+          client.request(apiCall._1, apiCall._2).addAuthentication("token").sendFuture() shouldAnswerWith UNAUTHORIZED
         }
         it(s"if token isn't valid, doing ${apiCall._1.toString} on ${apiCall._2}") {
           client.request(apiCall._1, apiCall._2)
             .addAuthentication("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6InRpemlvIn0.f6eS98GeBmPau4O58NwQa_XRu3Opv6qWxYISWU78F68")
-            .sendFuture() shouldAnswerWith 401
+            .sendFuture() shouldAnswerWith UNAUTHORIZED
         }
       }
     }
@@ -251,19 +253,19 @@ class RoomsServiceVerticleTest extends RoomsWebServiceTesting with RoomApiWrappe
 
   override protected def onWrongRoomID(apiCall: String => Future[_]): Unit = {
     it("if roomID is empty") {
-      apiCall("").mapTo[HttpResponse[Buffer]] shouldAnswerWith 400
+      apiCall("").mapTo[HttpResponse[Buffer]] shouldAnswerWith BAD_REQUEST
     }
     it("if provided roomID is not present") {
-      apiCall("1234214").mapTo[HttpResponse[Buffer]] shouldAnswerWith 404
+      apiCall("1234214").mapTo[HttpResponse[Buffer]] shouldAnswerWith NOT_FOUND
     }
   }
 
   override protected def onWrongPlayersNumber(apiCall: Int => Future[_]): Unit = {
     it("if players number provided less than 2") {
-      apiCall(0).mapTo[HttpResponse[Buffer]] shouldAnswerWith 400
+      apiCall(0).mapTo[HttpResponse[Buffer]] shouldAnswerWith BAD_REQUEST
     }
     it("if room with such players number doesn't exist") {
-      apiCall(TOO_BIG_PLAYERS_NUMBER).mapTo[HttpResponse[Buffer]] shouldAnswerWith 404
+      apiCall(TOO_BIG_PLAYERS_NUMBER).mapTo[HttpResponse[Buffer]] shouldAnswerWith NOT_FOUND
     }
   }
 

--- a/services/rooms/src/test/scala/it/cwmp/testing/rooms/RoomsWebServiceTesting.scala
+++ b/services/rooms/src/test/scala/it/cwmp/testing/rooms/RoomsWebServiceTesting.scala
@@ -1,11 +1,13 @@
 package it.cwmp.testing.rooms
 
+import io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED
 import io.vertx.lang.scala.ScalaVerticle
 import it.cwmp.exceptions.HTTPException
 import it.cwmp.model.{Address, Participant, User}
 import it.cwmp.services.rooms.RoomsServiceVerticle
 import it.cwmp.services.wrapper.RoomReceiverApiWrapper
 import it.cwmp.testing.VerticleBeforeAndAfterEach
+import it.cwmp.utils.Utils.httpStatusNameToCode
 import it.cwmp.utils.{HttpUtils, Validation}
 
 import scala.concurrent.Future
@@ -51,9 +53,9 @@ abstract class RoomsWebServiceTesting extends RoomsTesting with VerticleBeforeAn
     override def validate(authorizationHeader: String): Future[User] = HttpUtils.readJwtAuthentication(authorizationHeader) match {
       case Some(token) => participants.get(token) match {
         case Some(participant) => Future.successful(participant)
-        case _ => Future.failed(HTTPException(401))
+        case _ => Future.failed(HTTPException(UNAUTHORIZED))
       }
-      case _ => Future.failed(HTTPException(401))
+      case _ => Future.failed(HTTPException(UNAUTHORIZED))
     }
   }
 


### PR DESCRIPTION
- Added a Utility method to implicitly convert Status code names to integer codes
- Replaced all status code numbers with their mnemonical names through the project
- Added error messages in AuthenticationLocalDAO
- Refactored AuthenticationServiceVerticleTest with for comprhension