### PR TITLE
[SPRINT6] Added Passive Cells to generated world

### DIFF
--- a/client/src/main/scala/it/cwmp/client/controller/ClientControllerActor.scala
+++ b/client/src/main/scala/it/cwmp/client/controller/ClientControllerActor.scala
@@ -5,7 +5,7 @@ import it.cwmp.client.controller.AlertMessages.{Error, Info}
 import it.cwmp.client.controller.ClientControllerActor._
 import it.cwmp.client.controller.PlayerActor.{PrepareForGame, RetrieveAddress, RetrieveAddressResponse}
 import it.cwmp.client.controller.ViewVisibilityMessages.{Hide, Show}
-import it.cwmp.client.controller.game.CellWorldGenerationStrategy
+import it.cwmp.client.controller.game.{CellWorldGenerationStrategy, GameConstants}
 import it.cwmp.client.controller.messages.AuthenticationRequests.{GUILogOut, LogIn, SignUp}
 import it.cwmp.client.controller.messages.AuthenticationResponses.{LogInFailure, LogInSuccess, SignUpFailure, SignUpSuccess}
 import it.cwmp.client.controller.messages.Initialize
@@ -255,7 +255,7 @@ case class ClientControllerActor() extends Actor with ParticipantListReceiver wi
     context.become(inGameBehaviour)
     roomViewActor ! Hide
     playerActor ! PrepareForGame(participants,
-      CellWorldGenerationStrategy(GameViewActor.VIEW_SIZE, GameViewActor.VIEW_SIZE))
+      CellWorldGenerationStrategy(GameViewActor.VIEW_SIZE, GameViewActor.VIEW_SIZE, GameConstants.PASSIVE_CELLS_NUMBER))
   }
 }
 

--- a/client/src/main/scala/it/cwmp/client/controller/game/CellWorldGenerationStrategy.scala
+++ b/client/src/main/scala/it/cwmp/client/controller/game/CellWorldGenerationStrategy.scala
@@ -2,50 +2,93 @@ package it.cwmp.client.controller.game
 
 import java.time.Instant
 
-import it.cwmp.client.controller.game.CellWorldGenerationStrategy.{MINIMUM_DISTANCE_BETWEEN_CELLS, MINIMUM_DISTANCE_FROM_BORDER}
+import it.cwmp.client.controller.game.CellWorldGenerationStrategy.{MINIMUM_DISTANCE_BETWEEN_CELLS, MINIMUM_DISTANCE_FROM_BORDER, randomMutatePoint, randomPoint}
 import it.cwmp.client.model.game.impl.{Cell, CellWorld, Point}
 import it.cwmp.client.view.game.model.CellView
-import it.cwmp.model.Participant
+import it.cwmp.model.User
 
 import scala.util.Random
 
 /**
   * A class implementing a CellWorld generation strategy
   *
+  * @param worldHeight  the height of the world
+  * @param worldWidth   the width of the world
+  * @param passiveCells the number of passive cells to generate
   * @author Enrico Siboni
   */
-case class CellWorldGenerationStrategy(worldHeight: Int, worldWidth: Int) extends GenerationStrategy[Seq[Participant], CellWorld] {
+case class CellWorldGenerationStrategy(worldHeight: Int, worldWidth: Int, passiveCells: Int) extends GenerationStrategy[Seq[User], CellWorld] {
+  require(worldHeight > 0, "World height should be greater that 0")
+  require(worldWidth > 0, "World width should be greater that 0")
+  require(passiveCells >= 0, "Passive cells number should be positive")
 
   /**
     * Generates the world starting from a participant list
     *
-    * @param participants the participants to game
+    * @param players the participants to game
     * @return the generated world starting from participants
     */
-  override def apply(participants: Seq[Participant]): CellWorld =
-    CellWorld(Instant.now(), getParticipantCells(participants), Seq())
+  override def apply(players: Seq[User]): CellWorld =
+    CellWorld(Instant.now(), generateWorldCells(players, passiveCells), Seq())
+
+  /**
+    * A method to generate world cells in a way that they don't overlap
+    *
+    * @param players              the participants to game for wich to generate cells
+    * @param numberOfPassiveCells the number of passive cells to generate among others
+    * @return generated cells
+    */
+  def generateWorldCells(players: Seq[User], numberOfPassiveCells: Int): Seq[Cell] = {
+    val participantCells = getParticipantCells(players)
+    participantCells ++ randomPassiveCells(numberOfPassiveCells, participantCells.map(_.position))
+  }
 
   /**
     * A method to position participant cells into game world
     *
-    * @param participants the participants to assign a cell into the world
+    * @param players the participants to assign a cell into the world
     * @return the cells assigned to participants
     */
-  def getParticipantCells(participants: Seq[Participant]): Seq[Cell] = {
-
-    def randomPoint = Point(Random.nextInt(worldWidth + 1), Random.nextInt(worldHeight + 1))
-
+  def getParticipantCells(players: Seq[User]): Seq[Cell] = {
     var selectedPoints: Seq[Point] = Seq()
-    for (participant <- participants) yield {
-      var toCheck = randomPoint
-      while (!pointValid(toCheck, selectedPoints)) toCheck = randomPoint
-      selectedPoints = selectedPoints :+ toCheck
-      Cell(participant, randomPoint)
+    for (player <- players) yield {
+      val validPoint = getValidPoint(selectedPoints)
+      selectedPoints = selectedPoints :+ validPoint
+      Cell(player, validPoint)
     }
   }
 
   /**
-    * Determines if the point to check is valid;
+    * A method to generate a certain number of passive cells to be placed into world
+    *
+    * @param numberOfPassiveCells  the number of passive cells to place
+    * @param alreadyOccupiedPlaces those places already occupied
+    * @return the passive cells placed
+    */
+  def randomPassiveCells(numberOfPassiveCells: Int, alreadyOccupiedPlaces: Seq[Point]): Seq[Cell] = {
+    var selectedPoints: Seq[Point] = alreadyOccupiedPlaces
+    for (_ <- 0 until numberOfPassiveCells) yield {
+      val validPoint = getValidPoint(selectedPoints)
+      selectedPoints = selectedPoints :+ validPoint
+      Cell(Cell.Passive.NO_OWNER, validPoint, GameConstants.PASSIVE_CELL_ENERGY_WHEN_BORN)
+    }
+  }
+
+  /**
+    * A method to get a valid point for a cell;
+    * that is a point which is not overlapping other cells and distant from world border
+    *
+    * @param alreadySelectedPoints the already selected points
+    * @return the point that is valid according to rules
+    */
+  private def getValidPoint(alreadySelectedPoints: Seq[Point]): Point = {
+    var point = randomPoint(worldWidth, worldHeight)
+    while (!pointValid(point, alreadySelectedPoints)) point = randomMutatePoint(point, worldWidth, worldHeight)
+    point
+  }
+
+  /**
+    * Determines if the point in which to place a cell is valid;
     *
     * A point is valid when it's distance from borders is respected and also the distance from other cells is respected
     *
@@ -65,6 +108,28 @@ case class CellWorldGenerationStrategy(worldHeight: Int, worldWidth: Int) extend
   * Companion object
   */
 object CellWorldGenerationStrategy {
-  private val MINIMUM_DISTANCE_FROM_BORDER = CellView.CELL_MAX_RADIUS_FOR_ENERGY._1
-  private val MINIMUM_DISTANCE_BETWEEN_CELLS = CellView.CELL_MAX_RADIUS_FOR_ENERGY._1 * 2
+  private val MINIMUM_DISTANCE_FROM_BORDER = CellView.CELL_MAX_RADIUS_FOR_ENERGY._1 / 2
+  private val MINIMUM_DISTANCE_BETWEEN_CELLS = CellView.CELL_MAX_RADIUS_FOR_ENERGY._1 / 2
+
+  /**
+    * Returns a random point with coordinates between 0 and max values (inclusive)
+    *
+    * @param maxX the max X of any generated point
+    * @param maxY the max Y of any generated point
+    * @return the generated point
+    */
+  private def randomPoint(maxX: Int, maxY: Int): Point = Point(Random.nextInt(maxX + 1), Random.nextInt(maxY + 1))
+
+  /**
+    * Mutates a point randomly in x or y component, leaving other as is
+    *
+    * @param point the point to mutate
+    * @param maxX  the max x coordinate value
+    * @param maxY  the max y coordinate value
+    * @return the mutated point
+    */
+  private def randomMutatePoint(point: Point, maxX: Int, maxY: Int): Point = Random.nextInt() match {
+    case randomInt: Int if randomInt % 2 == 0 => Point((point.x * randomInt) % maxX, point.y)
+    case randomInt: Int => Point(point.x, (point.y * randomInt) % maxY)
+  }
 }

--- a/client/src/main/scala/it/cwmp/client/controller/game/CellWorldGenerationStrategy.scala
+++ b/client/src/main/scala/it/cwmp/client/controller/game/CellWorldGenerationStrategy.scala
@@ -108,7 +108,7 @@ case class CellWorldGenerationStrategy(worldHeight: Int, worldWidth: Int, passiv
   */
 object CellWorldGenerationStrategy {
   private val MINIMUM_DISTANCE_FROM_BORDER = CellView.CELL_MAX_RADIUS_FOR_ENERGY._1
-  private val MINIMUM_DISTANCE_BETWEEN_CELLS = CellView.CELL_MAX_RADIUS_FOR_ENERGY._1
+  private val MINIMUM_DISTANCE_BETWEEN_CELLS = CellView.CELL_MAX_RADIUS_FOR_ENERGY._1 * 2
 
   /**
     * Returns a random point with coordinates between 0 and max values (inclusive)

--- a/client/src/main/scala/it/cwmp/client/controller/game/GameConstants.scala
+++ b/client/src/main/scala/it/cwmp/client/controller/game/GameConstants.scala
@@ -22,6 +22,18 @@ object GameConstants {
   val MILLIS_TO_ENERGY_CONVERSION_RATE = 1000d
 
   /**
+    * ==Passive Cell==
+    *
+    * The energy that a passive cell has when it's born
+    */
+  val PASSIVE_CELL_ENERGY_WHEN_BORN = 40d
+
+  /**
+    * Time needed to conquer a passive cell (expressed in milliseconds)
+    */
+  val MILLIS_TO_PASSIVE_CELL_CONQUER = 3000
+
+  /**
     * ==Tentacle==
     *
     * Amount of time expressed in milliseconds that will be converted to a movement step of the tentacle

--- a/client/src/main/scala/it/cwmp/client/controller/game/GameConstants.scala
+++ b/client/src/main/scala/it/cwmp/client/controller/game/GameConstants.scala
@@ -53,4 +53,9 @@ object GameConstants {
     * Amount of time expressed in milliseconds that will be converted in 1 energy reduction on under attack character
     */
   val ATTACK_DURATION_TO_ENERGY_REDUCTION_RATE = 1000d
+
+  /**
+    * The number of passive cells in generated world
+    */
+  val PASSIVE_CELLS_NUMBER = 5
 }

--- a/client/src/main/scala/it/cwmp/client/model/game/impl/Cell.scala
+++ b/client/src/main/scala/it/cwmp/client/model/game/impl/Cell.scala
@@ -110,11 +110,6 @@ object Cell {
     val NO_OWNER: User = User("_NO_OWNER_")
 
     /**
-      * Energy of a passive cell when born
-      */
-    val CELL_ENERGY_WHEN_BORN = 40
-
-    /**
       * Default evolution strategy for a passive cell
       *
       * Does nothing

--- a/client/src/main/scala/it/cwmp/client/model/game/impl/Cell.scala
+++ b/client/src/main/scala/it/cwmp/client/model/game/impl/Cell.scala
@@ -99,4 +99,28 @@ object Cell {
 
   }
 
+  /**
+    * Constants for cells that are passive... that is with no owner
+    */
+  object Passive {
+
+    /**
+      * Placeholder User for cells with no owner
+      */
+    val NO_OWNER: User = User("_NO_OWNER_")
+
+    /**
+      * Energy of a passive cell when born
+      */
+    val CELL_ENERGY_WHEN_BORN = 40
+
+    /**
+      * Default evolution strategy for a passive cell
+      *
+      * Does nothing
+      */
+    val defaultEvolutionStrategy: EvolutionStrategy[Cell, Duration] = (cell, _) => cell
+
+  }
+
 }

--- a/client/src/main/scala/it/cwmp/client/view/game/model/CellView.scala
+++ b/client/src/main/scala/it/cwmp/client/view/game/model/CellView.scala
@@ -61,6 +61,8 @@ object CellView {
   private val CELL_BORDER =
     new Border(new BorderStroke(CELL_BORDER_COLOR, BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderWidths.DEFAULT))
 
+  private val PASSIVE_CELL_COLOR = Color.LIGHTGREY
+
   /**
     * Implicit Conversion from Cell to CellView
     *
@@ -76,16 +78,22 @@ object CellView {
     * Color based on the username hash value
     */
   val coloringStrategy: ColoringStrategy[Cell, Color] = (cell: Cell) => {
-    implicit def colorFromRGB(userColor: Rgb): Color =
-      new Color(userColor.red / RGB_RANGE, userColor.green / RGB_RANGE, userColor.blue / RGB_RANGE, CELL_VIEW_COLOR_OPACITY)
+    if (cell.owner == Cell.Passive.NO_OWNER) {
+      PASSIVE_CELL_COLOR
+    } else {
+      implicit def colorFromRGB(userColor: Rgb): Color =
+        new Color(userColor.red / RGB_RANGE, userColor.green / RGB_RANGE, userColor.blue / RGB_RANGE, CELL_VIEW_COLOR_OPACITY)
 
-    val colorHash = new ColorHash()
-    val username = cell.owner.username
-    val userColor: Color = colorHash.rgb(username)
-    // if userName hash gives a color used in GUI take another color
-    if (Seq(GAME_DEFAULT_FONT_COLOR, CELL_DYING_FONT_COLOR, GAME_TIME_TEXT_COLOR).contains(userColor)) {
-      colorHash.rgb(username.substring(username.length / 2))
-    } else userColor
+      val colorHash = new ColorHash()
+      val username = cell.owner.username
+      val userColor: Color = colorHash.rgb(username)
+      // if userName hash gives a color used in GUI take another color
+      if (Seq(GAME_DEFAULT_FONT_COLOR, CELL_DYING_FONT_COLOR, GAME_TIME_TEXT_COLOR, PASSIVE_CELL_COLOR).contains(userColor)) {
+        colorHash.rgb(username.substring(username.length / 2))
+      } else {
+        userColor
+      }
+    }
   }
 
   /**

--- a/client/src/main/scala/it/cwmp/client/view/game/model/CellView.scala
+++ b/client/src/main/scala/it/cwmp/client/view/game/model/CellView.scala
@@ -47,12 +47,12 @@ object CellView {
   /**
     * Pair of CellView min radius and energy for that radius
     */
-  val CELL_MINIMUM_RADIUS_FOR_ENERGY = (25d, 20d)
+  val CELL_MINIMUM_RADIUS_FOR_ENERGY: (Double, Double) = (25d, 20d)
 
   /**
     * Pair of CellView max radius and energy for that radius
     */
-  val CELL_MAX_RADIUS_FOR_ENERGY = (45d, 100d)
+  val CELL_MAX_RADIUS_FOR_ENERGY: (Double, Double) = (45d, 100d)
 
   private val CELL_VIEW_COLOR_OPACITY = 1
   private val CELL_DYING_FONT_COLOR = Color.DARKRED

--- a/client/src/test/scala/it/cwmp/client/controller/game/CellWorldGenerationStrategyTest.scala
+++ b/client/src/test/scala/it/cwmp/client/controller/game/CellWorldGenerationStrategyTest.scala
@@ -1,0 +1,44 @@
+package it.cwmp.client.controller.game
+
+import it.cwmp.client.model.game.impl.Cell
+import it.cwmp.model.User
+import org.scalatest.FunSpec
+
+/**
+  * A test class for CellWorldGenerationStrategy
+  *
+  * @author Enrico Siboni
+  */
+class CellWorldGenerationStrategyTest extends FunSpec {
+
+  private val worldWidth = 500
+  private val worldHeight = 500
+  private val passiveCells = 0
+
+  private val negativeValue = -5
+
+  private val myParticipants = Seq(User("Enrico"), User("Eugenio"), User("Davide"), User("Elia"))
+
+  describe("A CellWorldGenerationStrategy") {
+    describe("should complain") {
+      it("when provided wrong parameters") {
+        intercept[IllegalArgumentException](CellWorldGenerationStrategy(negativeValue, worldWidth, passiveCells))
+        intercept[IllegalArgumentException](CellWorldGenerationStrategy(worldHeight, negativeValue, passiveCells))
+        intercept[IllegalArgumentException](CellWorldGenerationStrategy(worldHeight, worldWidth, negativeValue))
+      }
+    }
+    describe("when input is correct") {
+      val cellWorld = CellWorldGenerationStrategy(worldHeight, worldWidth, passiveCells)(myParticipants)
+      it("should generate a world with correct number of participants") {
+        assert(cellWorld.characters.size == myParticipants.size + passiveCells)
+      }
+      it("should generate a world with correct number of passive cells") {
+        assert(cellWorld.characters.count(_.owner == Cell.Passive.NO_OWNER) == passiveCells)
+      }
+      it("should generate a CellWorld with no attacks") {
+        assert(cellWorld.attacks.isEmpty)
+      }
+    }
+  }
+
+}

--- a/client/src/test/scala/it/cwmp/client/controller/game/CellWorldGenerationStrategyTest.scala
+++ b/client/src/test/scala/it/cwmp/client/controller/game/CellWorldGenerationStrategyTest.scala
@@ -13,7 +13,7 @@ class CellWorldGenerationStrategyTest extends FunSpec {
 
   private val worldWidth = 500
   private val worldHeight = 500
-  private val passiveCells = 0
+  private val passiveCells = 5
 
   private val negativeValue = -5
 

--- a/client/src/test/scala/it/cwmp/client/controller/game/GameEngineTest.scala
+++ b/client/src/test/scala/it/cwmp/client/controller/game/GameEngineTest.scala
@@ -109,6 +109,9 @@ class GameEngineTest extends FunSpec {
         it("on conquer of cell") {
           assert(!afterConquerOfCellWorld.characters.exists(_.owner.username == "Enrico"))
         }
+        it("conquering passive cells") {
+          assert(!afterConquerOfCellWorld.characters.exists(_.owner == NO_OWNER))
+        }
       }
 
       describe("Removing tentacles") {

--- a/client/src/test/scala/it/cwmp/client/controller/game/GameEngineTest.scala
+++ b/client/src/test/scala/it/cwmp/client/controller/game/GameEngineTest.scala
@@ -2,6 +2,7 @@ package it.cwmp.client.controller.game
 
 import java.time.{Duration, Instant}
 
+import it.cwmp.client.model.game.impl.Cell.Passive.NO_OWNER
 import it.cwmp.client.model.game.impl.{Cell, CellWorld, Point, Tentacle}
 import it.cwmp.model.User
 import org.scalatest.FunSpec
@@ -17,14 +18,17 @@ class GameEngineTest extends FunSpec {
   private val cells = Cell(User("Enrico"), Point(0, 0), 20) ::
     Cell(User("Elia"), Point(30, 40), 40) ::
     Cell(User("Davide"), Point(40, 30), 40) ::
+    Cell(NO_OWNER, Point(40, 40), GameConstants.PASSIVE_CELL_ENERGY_WHEN_BORN) ::
     Nil
   private val tentacles = Tentacle(cells(1), cells.head, worldInstant.minus(Duration.ofMillis(500))) ::
     Tentacle(cells(2), cells.head, worldInstant) ::
+    Tentacle(cells(2), cells(3), worldInstant) ::
     Nil
 
   // this is a world where Elia and Davide are attacking Enrico...
   // Elia attacked Enrico 500 milliseconds before Davide
   // after some time Enrico will be conquered by Elia, because he is the first attacker
+  // Davide will conquer a passive cell near him
   private val myCellWorld = CellWorld(worldInstant, cells, tentacles)
 
   private val notEnoughTimeToReachCell = Duration.ofSeconds(1)
@@ -63,11 +67,18 @@ class GameEngineTest extends FunSpec {
         assert(GameEngine(myCellWorld, Duration.ZERO) == myCellWorld)
       }
 
-      it("evolving only cell energy if no attacks are ongoing") {
+      it("evolving only active cell energy if no attacks are ongoing") {
         val noAttacksWorld = CellWorld(worldInstant, cells, Seq())
         val noAttacksWorldEvolved = GameEngine(noAttacksWorld, notEnoughTimeToReachCell)
         val baseAndEvolvedPair = noAttacksWorld.characters.zipAll(noAttacksWorldEvolved.characters, cells.head, cells.head)
-        assert(baseAndEvolvedPair.forall(pair => pair._1.energy < pair._2.energy))
+        assert(baseAndEvolvedPair.filter(_._1.owner != NO_OWNER).forall(pair => pair._1.energy < pair._2.energy))
+      }
+
+      it("not evolving passive cell energy") {
+        val passiveCells = myCellWorld.characters.filter(_.owner == NO_OWNER)
+        val passiveEvolvedCells = beforeAttackWorld.characters.filter(_.owner == NO_OWNER)
+        assert(passiveCells.zip(passiveEvolvedCells)
+          .forall(cellPair => cellPair._1.energy == cellPair._2.energy))
       }
 
       it("increasing time by provided duration") {

--- a/client/src/test/scala/it/cwmp/client/model/game/impl/CellTest.scala
+++ b/client/src/test/scala/it/cwmp/client/model/game/impl/CellTest.scala
@@ -2,6 +2,7 @@ package it.cwmp.client.model.game.impl
 
 import java.time.Duration
 
+import it.cwmp.client.model.game.GeometricUtils
 import it.cwmp.model.User
 import org.scalatest.FunSpec
 
@@ -16,8 +17,12 @@ class CellTest extends FunSpec {
   private val position = Point(3, 4)
   private val energy = 50
 
+  private val negativeNumber = -5
+
   private val myCell = Cell(user, position, energy)
   private val anotherCell = Cell(user, Point(0, 0), energy * 2)
+
+  private val timeDuration = Duration.ofSeconds(1)
 
   describe("A cell") {
     describe("On creation") {
@@ -31,17 +36,18 @@ class CellTest extends FunSpec {
       describe("should complain") {
         it("on bad owner")(intercept[NullPointerException](Cell(null, position, energy)))
         it("on bad position")(intercept[NullPointerException](Cell(user, null, energy)))
-        it("on bad energy value")(intercept[IllegalArgumentException](Cell(user, position, -5)))
+        it("on bad energy value")(intercept[IllegalArgumentException](Cell(user, position, negativeNumber)))
       }
     }
 
     it("Distance calculation should be correct") {
-      assert(Cell.distance(myCell, anotherCell) == 5)
+      val distance = GeometricUtils.distance(myCell.position, anotherCell.position)
+      assert(Cell.distance(myCell, anotherCell) == distance)
     }
 
     describe("Evolution") {
       it("should increment energy") {
-        val myEvolvedCell = Cell.defaultEvolutionStrategy(myCell, Duration.ofSeconds(20))
+        val myEvolvedCell = Cell.defaultEvolutionStrategy(myCell, timeDuration)
 
         assert(myEvolvedCell.energy > myCell.energy)
         assert(myEvolvedCell.position == myCell.position)
@@ -49,21 +55,21 @@ class CellTest extends FunSpec {
       }
       it("should increment energy in multiple times") {
         // the evolution strategy increases energy every second
-        val myEvolvedCell = Cell.defaultEvolutionStrategy(myCell, Duration.ofMillis(5))
+        val myEvolvedCell = Cell.defaultEvolutionStrategy(myCell, timeDuration)
         assert(myEvolvedCell.energy > myCell.energy)
 
-        val mySecondEvolvedCell = Cell.defaultEvolutionStrategy(myEvolvedCell, Duration.ofMillis(5))
+        val mySecondEvolvedCell = Cell.defaultEvolutionStrategy(myEvolvedCell, timeDuration)
         assert(mySecondEvolvedCell.energy > myEvolvedCell.energy)
       }
       it("should use default strategy with implicit") {
-        val evolvedCell = myCell.evolve(Duration.ofMillis(1000))
+        val evolvedCell = myCell.evolve(timeDuration)
 
         assert(myCell.energy < evolvedCell.energy)
       }
     }
 
     it("can match by owner and position regardless energy") {
-      val myEvolvedCell = Cell.defaultEvolutionStrategy(myCell, Duration.ofMillis(500))
+      val myEvolvedCell = Cell.defaultEvolutionStrategy(myCell, timeDuration)
 
       assert(Cell.ownerAndPositionMatch(myCell, myEvolvedCell))
     }
@@ -86,8 +92,23 @@ class CellTest extends FunSpec {
         assert(decrementedCell eq myCell)
       }
       describe("should complain if") {
-        it("increment amount not positive")(intercept[IllegalArgumentException](myCell ++ -2))
-        it("decrement amount not positive")(intercept[IllegalArgumentException](myCell -- -2))
+        it("increment amount not positive")(intercept[IllegalArgumentException](myCell ++ negativeNumber))
+        it("decrement amount not positive")(intercept[IllegalArgumentException](myCell -- negativeNumber))
+      }
+    }
+
+    describe("When Passive") {
+      val passiveCell = Cell(Cell.Passive.NO_OWNER, position, Cell.Passive.CELL_ENERGY_WHEN_BORN)
+      it("should have no owner") {
+        assert(passiveCell.owner == Cell.Passive.NO_OWNER)
+      }
+
+      it("should not evolve") {
+        val evolvedCell1 = Cell.Passive.defaultEvolutionStrategy(passiveCell, timeDuration)
+        val evolvedCell2 = passiveCell.evolve(timeDuration, Cell.Passive.defaultEvolutionStrategy)
+
+        assert(evolvedCell1.energy == passiveCell.energy)
+        assert(evolvedCell2.energy == passiveCell.energy)
       }
     }
   }

--- a/client/src/test/scala/it/cwmp/client/model/game/impl/CellTest.scala
+++ b/client/src/test/scala/it/cwmp/client/model/game/impl/CellTest.scala
@@ -2,6 +2,7 @@ package it.cwmp.client.model.game.impl
 
 import java.time.Duration
 
+import it.cwmp.client.controller.game.GameConstants
 import it.cwmp.client.model.game.GeometricUtils
 import it.cwmp.model.User
 import org.scalatest.FunSpec
@@ -98,7 +99,7 @@ class CellTest extends FunSpec {
     }
 
     describe("When Passive") {
-      val passiveCell = Cell(Cell.Passive.NO_OWNER, position, Cell.Passive.CELL_ENERGY_WHEN_BORN)
+      val passiveCell = Cell(Cell.Passive.NO_OWNER, position, GameConstants.PASSIVE_CELL_ENERGY_WHEN_BORN)
       it("should have no owner") {
         assert(passiveCell.owner == Cell.Passive.NO_OWNER)
       }


### PR DESCRIPTION
- Refactored `CellWorldGenerationStategy` to generate random "passive" cells (those cells that can be conquered by players and are dead)
- Solved an error in generation strategy `pointValid` method that made impossible to generate a world with lot of cells
- Added passive cells `GameConstants`
- Modified `GameEngine` to deal with this new type of cell
- Added a check in `GameViewActor` that no more permits to add more than one attack to same cell
- Modified `CellView` coloring strategy to color passive cells with grey color
- Added tests for CellViewgenerationStrategy
- Modified existing `GameEngineTest` and `CellTest` to test PassiveCell new feature