### PR TITLE
[SPRINT6] ScalaStyle configuration tuning

### DIFF
--- a/client/src/test/scala/it/cwmp/client/model/game/GeometricUtilsTest.scala
+++ b/client/src/test/scala/it/cwmp/client/model/game/GeometricUtilsTest.scala
@@ -98,6 +98,7 @@ class GeometricUtilsTest extends PropSpec with PropertyChecks with Matchers {
           else {
             if (point1.x > point2.x) assert(deltaXY._1 < 0) // if point1 on the right of point2 -> delta X should be negative
             else assert(deltaXY._1 > 0) // positive otherwise
+
             if (point1.y > point2.y) assert(deltaXY._2 < 0) // if point1 above point2 -> delta Y should be negative
             else assert(deltaXY._2 > 0) // positive otherwise
           }

--- a/scalastyle_config.xml
+++ b/scalastyle_config.xml
@@ -1,33 +1,39 @@
 <scalastyle commentFilter="enabled">
-    <name>Scalastyle standard configuration</name>
-    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <name>Scalastyle configuration</name>
+    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
         <parameters>
             <parameter name="maxFileLength"><![CDATA[800]]></parameter>
         </parameters>
     </check>
-    <!--<check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
         <parameters>
-            <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
-// See the LICENCE.txt file distributed with this work for additional
-// information regarding copyright ownership.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.]]></parameter>
+            <parameter name="header">
+                <![CDATA[
+                    // Copyright (C) 2011-2012 the original author or authors.
+                    // See the LICENCE.txt file distributed with this work for additional
+                    // information regarding copyright ownership.
+                    //
+                    // Licensed under the Apache License, Version 2.0 (the "License");
+                    // you may not use this file except in compliance with the License.
+                    // You may obtain a copy of the License at
+                    //
+                    // http://www.apache.org/licenses/LICENSE-2.0
+                    //
+                    // Unless required by applicable law or agreed to in writing, software
+                    // distributed under the License is distributed on an "AS IS" BASIS,
+                    // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                ]]>
+            </parameter>
         </parameters>
-    </check>-->
-    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker"
+           enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker"
+           enabled="true"/>
     <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
         <parameters>
             <parameter name="maxLineLength"><![CDATA[160]]></parameter>
@@ -44,12 +50,13 @@
             <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker"
+           enabled="true">
         <parameters>
             <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>
             <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
@@ -65,14 +72,17 @@
             <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker"
+           enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker"
+           enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker"
+           enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
         <parameters>
             <parameter name="regex"><![CDATA[println]]></parameter>
@@ -83,13 +93,15 @@
             <parameter name="maxTypes"><![CDATA[30]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker"
+           enabled="true">
         <parameters>
             <parameter name="maximum"><![CDATA[10]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker"
+           enabled="true"/>
     <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>
             <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
@@ -106,37 +118,43 @@
             <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker"
+           enabled="true">
         <parameters>
             <parameter name="maxMethods"><![CDATA[30]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
-    <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="false"></check>
-    <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"></check>
-    <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
-    <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker"
+           enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
+    <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="false"/>
+    <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"/>
+    <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"/>
+    <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"/>
     <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
         <parameters>
             <parameter name="regex"><![CDATA[println]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+    <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker"
+           enabled="true">
         <parameters>
             <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+    <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker"
+           enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker"
+           enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker"
+           enabled="true">
         <parameters>
             <parameter name="allowed"><![CDATA[2]]></parameter>
             <parameter name="ignoreRegex"><![CDATA[^""$]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"/>
 </scalastyle>

--- a/scalastyle_config.xml
+++ b/scalastyle_config.xml
@@ -105,7 +105,7 @@
     <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>
             <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
-            <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+            <parameter name="doubleLineAllowed"><![CDATA[true]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">

--- a/scalastyle_config.xml
+++ b/scalastyle_config.xml
@@ -154,7 +154,7 @@
            enabled="true">
         <parameters>
             <parameter name="allowed"><![CDATA[2]]></parameter>
-            <parameter name="ignoreRegex"><![CDATA[^"+$]]></parameter>
+            <parameter name="ignoreRegex"><![CDATA["+]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"/>

--- a/scalastyle_config.xml
+++ b/scalastyle_config.xml
@@ -1,5 +1,5 @@
 <scalastyle commentFilter="enabled">
-    <name>Scalastyle configuration</name>
+    <name>ScalaStyle configuration</name>
     <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
         <parameters>
@@ -131,29 +131,30 @@
     <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="false"/>
     <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"/>
     <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"/>
-    <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"/>
+    <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
         <parameters>
             <parameter name="regex"><![CDATA[println]]></parameter>
         </parameters>
+        <customMessage>Use logger instead of println</customMessage>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker"
            enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
+            <parameter name="regex"><![CDATA[^([A-Z_]|([A-Z][a-z]+)+)$]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker"
-           enabled="true"/>
+           enabled="false"/>
     <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker"
            enabled="true"/>
     <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker"
            enabled="true">
         <parameters>
             <parameter name="allowed"><![CDATA[2]]></parameter>
-            <parameter name="ignoreRegex"><![CDATA[^""$]]></parameter>
+            <parameter name="ignoreRegex"><![CDATA[^"+$]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"/>


### PR DESCRIPTION
Reformatted scalaStyle XML file and modified rules so now:

- Does not complain on underscore imports anymore
- Does not complain of "" duplicated literals
- Does not complain anymore of long type parameters name
- Does not complain of double line "if" anymore