### PR TITLE
[SPRINT7] Client Jar BugFix

### DIFF
--- a/client/src/main/scala/it/cwmp/client/view/FXServiceViewActor.scala
+++ b/client/src/main/scala/it/cwmp/client/view/FXServiceViewActor.scala
@@ -3,8 +3,6 @@ package it.cwmp.client.view
 import akka.actor.{Actor, ActorRef}
 import it.cwmp.client.controller.messages.Initialize
 import it.cwmp.client.controller.{ActorAlertManagement, ActorViewVisibilityManagement}
-import javafx.application.Platform
-import javafx.embed.swing.JFXPanel
 
 /**
   * A base class representing a Service View actor with JavaFX underlying
@@ -16,12 +14,6 @@ abstract class FXServiceViewActor extends Actor with ActorAlertManagement with A
   protected def fxController: FXViewController with FXAlertsController with FXInputViewController
 
   protected var controllerActor: ActorRef = _
-
-  override def preStart(): Unit = {
-    super.preStart()
-    new JFXPanel // initializes JavaFX
-    Platform setImplicitExit false
-  }
 
   override def receive: Receive = alertBehaviour orElse visibilityBehaviour orElse {
     case Initialize => controllerActor = sender()

--- a/client/src/main/scala/it/cwmp/client/view/FXViewController.scala
+++ b/client/src/main/scala/it/cwmp/client/view/FXViewController.scala
@@ -1,6 +1,7 @@
 package it.cwmp.client.view
 
 import javafx.application.Platform
+import javafx.embed.swing.JFXPanel
 import javafx.fxml.FXMLLoader
 import javafx.scene.Scene
 import javafx.scene.layout.Pane
@@ -57,6 +58,8 @@ trait FXViewController {
     * Initialization of the view
     */
   private def initGUI(): Unit = {
+    new JFXPanel // initializes JavaFX
+
     // creates an instance of layout
     val loader = new FXMLLoader(getClass.getResource(layout))
     loader.setController(controller)
@@ -66,5 +69,6 @@ trait FXViewController {
     stage setOnCloseRequest (_ => onCloseAction())
     stage setScene new Scene(pane)
     stage setResizable false
+    Platform setImplicitExit false
   }
 }

--- a/client/src/main/scala/it/cwmp/client/view/authentication/AuthenticationFXController.scala
+++ b/client/src/main/scala/it/cwmp/client/view/authentication/AuthenticationFXController.scala
@@ -34,6 +34,7 @@ class AuthenticationFXController(strategy: AuthenticationStrategy) extends FXVie
     // adds a listener to reset fields on tab change
     tpMain.getSelectionModel.selectedItemProperty.addListener((_, _, _) => resetFields())
     btnSignIn.setDefaultButton(true)
+    tfSignInUsername.requestFocus()
   }
 
   override def resetFields(): Unit = {

--- a/client/src/main/scala/it/cwmp/client/view/room/RoomFXController.scala
+++ b/client/src/main/scala/it/cwmp/client/view/room/RoomFXController.scala
@@ -35,6 +35,7 @@ class RoomFXController(strategy: RoomStrategy) extends FXViewController with FXI
     super.showGUI()
     // adds a listener to reset fields on tab change
     tabPane.getSelectionModel.selectedItemProperty.addListener((_, _, _) => resetFields())
+    tfPrivateCreateRoomName.requestFocus()
   }
 
   override def resetFields(): Unit = {


### PR DESCRIPTION
If you double-clicked on client jar it would had let you in till when was time to show InGame GUI, and then nothing would had happened...

The bug was that we was setting implicitExit of JavaFX Platform to `false` in the wrong place.

- BugFixed this moving call to `Platform.setImplicitExit(false)` from generic ViewActor to `FXViewController` trait
- Improved GUI usability