### PR TITLE
[SPRINT7] GameView Actor message on GameEnd

### DIFF
--- a/client/src/main/resources/layouts/gameViewLayout.fxml
+++ b/client/src/main/resources/layouts/gameViewLayout.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.Group?>
+<?import javafx.scene.layout.AnchorPane?>
+<AnchorPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml">
+    <Group fx:id="root"/>
+</AnchorPane>

--- a/client/src/main/scala/it/cwmp/client/GameMain.scala
+++ b/client/src/main/scala/it/cwmp/client/GameMain.scala
@@ -10,6 +10,9 @@ import it.cwmp.client.view.game.GameViewActor
 import it.cwmp.client.view.game.GameViewActor._
 import it.cwmp.model.User
 
+/**
+  * An object to start a fake game world to test gameView
+  */
 object GameMain extends App {
   val APP_NAME = "ClientApp"
 

--- a/client/src/main/scala/it/cwmp/client/utils/LayoutRes.scala
+++ b/client/src/main/scala/it/cwmp/client/utils/LayoutRes.scala
@@ -8,4 +8,6 @@ object LayoutRes {
   val authenticationLayout: String = "/layouts/authenticationManagerLayout.fxml"
 
   val roomManagerLayout: String = "/layouts/roomManagerLayout.fxml"
+
+  val gameLayout:String = "/layouts/gameViewLayout.fxml"
 }

--- a/client/src/main/scala/it/cwmp/client/view/FXRunOnUIThread.scala
+++ b/client/src/main/scala/it/cwmp/client/view/FXRunOnUIThread.scala
@@ -1,6 +1,7 @@
 package it.cwmp.client.view
 
 import javafx.application.Platform
+import javafx.embed.swing.JFXPanel
 
 /**
   * A trait that gives a way to run tasks on JavaFX Application Thread without overhead
@@ -14,7 +15,9 @@ trait FXRunOnUIThread {
     *
     * @param task the task to run on GUI thread
     */
-  def runOnUIThread(task: Runnable): Unit =
+  def runOnUIThread(task: Runnable): Unit = {
+    new JFXPanel // initializes JavaFX
     if (Platform.isFxApplicationThread) task.run() else Platform.runLater(task)
+  }
 
 }

--- a/client/src/main/scala/it/cwmp/client/view/FXViewController.scala
+++ b/client/src/main/scala/it/cwmp/client/view/FXViewController.scala
@@ -57,7 +57,7 @@ trait FXViewController {
   /**
     * Initialization of the view
     */
-  private def initGUI(): Unit = {
+  protected def initGUI(): Unit = {
     new JFXPanel // initializes JavaFX
 
     // creates an instance of layout

--- a/client/src/main/scala/it/cwmp/client/view/authentication/AuthenticationFXController.scala
+++ b/client/src/main/scala/it/cwmp/client/view/authentication/AuthenticationFXController.scala
@@ -34,6 +34,10 @@ class AuthenticationFXController(strategy: AuthenticationStrategy) extends FXVie
     // adds a listener to reset fields on tab change
     tpMain.getSelectionModel.selectedItemProperty.addListener((_, _, _) => resetFields())
     btnSignIn.setDefaultButton(true)
+  }
+
+  override def showGUI(): Unit = {
+    super.showGUI()
     tfSignInUsername.requestFocus()
   }
 

--- a/client/src/main/scala/it/cwmp/client/view/authentication/AuthenticationFXController.scala
+++ b/client/src/main/scala/it/cwmp/client/view/authentication/AuthenticationFXController.scala
@@ -29,8 +29,8 @@ class AuthenticationFXController(strategy: AuthenticationStrategy) extends FXVie
   @FXML private var btnSignUp: Button = _
   @FXML private var btnSignUpReset: Button = _
 
-  override def showGUI(): Unit = {
-    super.showGUI()
+  override protected def initGUI(): Unit = {
+    super.initGUI()
     // adds a listener to reset fields on tab change
     tpMain.getSelectionModel.selectedItemProperty.addListener((_, _, _) => resetFields())
     btnSignIn.setDefaultButton(true)

--- a/client/src/main/scala/it/cwmp/client/view/game/CellWorldObjectDrawer.scala
+++ b/client/src/main/scala/it/cwmp/client/view/game/CellWorldObjectDrawer.scala
@@ -3,7 +3,6 @@ package it.cwmp.client.view.game
 import java.time.{Duration, Instant}
 
 import it.cwmp.client.view.game.model._
-import javafx.scene.canvas.GraphicsContext
 import javafx.scene.layout._
 import javafx.scene.paint.Color
 import javafx.scene.shape.{Line, SVGPath}
@@ -79,11 +78,10 @@ trait CellWorldObjectDrawer {
     * A method to draw elapsed time on GUI
     *
     * @param actualWorldInstant the actual World Instant
-    * @param graphicsContext    the graphic context on which to draw
+    * @param viewWidth          the view Width
     * @return the text to draw
     */
-  def drawInstant(actualWorldInstant: Instant)
-                 (implicit graphicsContext: GraphicsContext): Text = {
+  def drawInstant(actualWorldInstant: Instant, viewWidth: Double): Text = {
     val elapsedTimeFromBeginning: Duration = firstWorldInstantOption match {
       case Some(firstWorldInstant) => Duration.between(firstWorldInstant, actualWorldInstant)
       case None =>
@@ -95,7 +93,7 @@ trait CellWorldObjectDrawer {
     val instantText = new Text(GameViewConstants.GAME_TIME_TEXT_FORMAT.format(minutes, seconds))
     instantText.setFont(GameViewConstants.GAME_TIME_TEXT_FONT)
     instantText.setFill(GameViewConstants.GAME_TIME_TEXT_COLOR)
-    instantText.setX((graphicsContext.getCanvas.getWidth / 2) - (instantText.getLayoutBounds.getWidth / 2))
+    instantText.setX((viewWidth / 2) - (instantText.getLayoutBounds.getWidth / 2))
     instantText.setY(instantText.getLayoutBounds.getHeight)
     instantText
   }

--- a/client/src/main/scala/it/cwmp/client/view/game/GameFX.scala
+++ b/client/src/main/scala/it/cwmp/client/view/game/GameFX.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorRef
 import it.cwmp.client.model.game.impl.{Cell, CellWorld, Point}
 import it.cwmp.client.utils.LayoutRes
 import it.cwmp.client.view.game.model.{CellView, TentacleView}
-import it.cwmp.client.view.{FXRunOnUIThread, FXViewController}
+import it.cwmp.client.view.{FXAlertsController, FXViewController}
 import javafx.fxml.FXML
 import javafx.scene.canvas.Canvas
 import javafx.scene.input.MouseEvent
@@ -23,7 +23,7 @@ import scala.language.implicitConversions
   * @author contributor Enrico Siboni
   */
 case class GameFX(viewManagerActor: ActorRef, override val title: String, viewSize: Int, playerName: String)
-  extends CellWorldObjectDrawer with FXViewController with FXRunOnUIThread {
+  extends CellWorldObjectDrawer with FXViewController with FXAlertsController {
 
   @FXML private var root: Group = _
 

--- a/client/src/main/scala/it/cwmp/client/view/game/GameViewActor.scala
+++ b/client/src/main/scala/it/cwmp/client/view/game/GameViewActor.scala
@@ -10,7 +10,7 @@ import it.cwmp.client.controller.messages.Initialize
 import it.cwmp.client.model.game.distributed.AkkaDistributedState.UpdateState
 import it.cwmp.client.model.game.impl._
 import it.cwmp.client.utils.GeometricUtils
-import it.cwmp.client.view.{FXAlertsController, FXRunOnUIThread}
+import it.cwmp.client.view.FXRunOnUIThread
 import it.cwmp.client.view.game.GameViewActor._
 import it.cwmp.client.view.game.model.{CellView, TentacleView}
 import it.cwmp.utils.Logging

--- a/client/src/main/scala/it/cwmp/client/view/room/RoomFXController.scala
+++ b/client/src/main/scala/it/cwmp/client/view/room/RoomFXController.scala
@@ -35,6 +35,10 @@ class RoomFXController(strategy: RoomStrategy) extends FXViewController with FXI
     super.initGUI()
     // adds a listener to reset fields on tab change
     tabPane.getSelectionModel.selectedItemProperty.addListener((_, _, _) => resetFields())
+  }
+
+  override def showGUI(): Unit = {
+    super.showGUI()
     tfPrivateCreateRoomName.requestFocus()
   }
 

--- a/client/src/main/scala/it/cwmp/client/view/room/RoomFXController.scala
+++ b/client/src/main/scala/it/cwmp/client/view/room/RoomFXController.scala
@@ -31,8 +31,8 @@ class RoomFXController(strategy: RoomStrategy) extends FXViewController with FXI
   @FXML private var btnPrivateEnter: Button = _
   @FXML private var btnPublicEnter: Button = _
 
-  override def showGUI(): Unit = {
-    super.showGUI()
+  override def initGUI(): Unit = {
+    super.initGUI()
     // adds a listener to reset fields on tab change
     tabPane.getSelectionModel.selectedItemProperty.addListener((_, _, _) => resetFields())
     tfPrivateCreateRoomName.requestFocus()


### PR DESCRIPTION
Added ability to GameViewActor to send a message to clients when the game ends, but lets the continue watching.

- Added a gameLayout to resources
- Modified `FXRunOnUIThread` to ensure _JavaFX_ initialized
- Modified `FXViewController` to make `initGUI` overridable
- Modified `CellWorldObjectDrawer` `drawInstant` to not require the `graphicContext` to know only the view size
- Refactored `GameFX` to adapt to general structure of `FXViewController`s of Authentication and Rooms
- Modified `GameViewActor` to notify user when game has ended, telling him if he is the winner or a loser